### PR TITLE
Get duration from the underlaying asset instead of from AVPlayerItem

### DIFF
--- a/ios/Classes/AudioplayersPlugin.m
+++ b/ios/Classes/AudioplayersPlugin.m
@@ -245,7 +245,7 @@ FlutterMethodChannel *_channel_audioplayer;
   NSMutableDictionary * playerInfo = players[playerId];
   AVPlayer *player = playerInfo[@"player"];
 
-  CMTime duration = [ [player currentItem] duration ];
+  CMTime duration = [[[player currentItem]  asset] duration];
   NSLog(@"ios -> updateDuration...%f", CMTimeGetSeconds(duration));
   if(CMTimeGetSeconds(duration)>0){
     NSLog(@"ios -> invokechannel");


### PR DESCRIPTION
Getting duration from directly from AVPlayerItem gives sometime a NaN 