### PR TITLE
Play audio from url with Http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [next]
+- Allow HTTP headers in `setUrl` (android only for now)
 
 ## 0.18.1
 - Fix kotlin config issue for some apps

--- a/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/Player.kt
@@ -15,7 +15,7 @@ abstract class Player {
     abstract fun pause()
 
     abstract fun configAttributes(respectSilence: Boolean, stayAwake: Boolean, duckAudio: Boolean)
-    abstract fun setUrl(url: String, isLocal: Boolean)
+    abstract fun setUrl(url: String, isLocal: Boolean, httpHeaders: Map<String,String> = emptyMap())
     abstract fun setDataSource(mediaDataSource: MediaDataSource?)
     abstract fun setVolume(volume: Double)
     abstract fun setRate(rate: Double)

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -2,6 +2,7 @@ package xyz.luan.audioplayers
 
 import android.content.Context
 import android.media.*
+import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
 
@@ -14,7 +15,7 @@ class WrappedMediaPlayer internal constructor(
 
     private var player: MediaPlayer? = null
     private var url: String? = null
-    private var httpHeaders: Map<String,String>? = null
+    private var httpHeaders: Map<String, String>? = null
     private var dataSource: MediaDataSource? = null
     private var volume = 1.0
     private var rate = 1.0f
@@ -31,12 +32,13 @@ class WrappedMediaPlayer internal constructor(
     /**
      * Setter methods
      */
-    override fun setUrl(url: String, isLocal: Boolean, httpHeaders: Map<String,String>) {
+    override fun setUrl(url: String, isLocal: Boolean, httpHeaders: Map<String, String>) {
         if (this.url != url || this.httpHeaders != httpHeaders) {
             this.url = url
             this.httpHeaders = httpHeaders
             val player = getOrCreatePlayer()
-            player.setDataSource(url, httpHeaders)
+            val uri = Uri.parse(url)
+            player.setDataSource(ref.getApplicationContext(), uri, httpHeaders)
             preparePlayer(player)
         }
 

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -14,6 +14,7 @@ class WrappedMediaPlayer internal constructor(
 
     private var player: MediaPlayer? = null
     private var url: String? = null
+    private var httpHeaders: Map<String,String>? = null
     private var dataSource: MediaDataSource? = null
     private var volume = 1.0
     private var rate = 1.0f
@@ -30,11 +31,12 @@ class WrappedMediaPlayer internal constructor(
     /**
      * Setter methods
      */
-    override fun setUrl(url: String, isLocal: Boolean) {
-        if (this.url != url) {
+    override fun setUrl(url: String, isLocal: Boolean, httpHeaders: Map<String,String>) {
+        if (this.url != url || this.httpHeaders != httpHeaders) {
             this.url = url
+            this.httpHeaders = httpHeaders
             val player = getOrCreatePlayer()
-            player.setDataSource(url)
+            player.setDataSource(url, httpHeaders)
             preparePlayer(player)
         }
 

--- a/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
+++ b/android/src/main/kotlin/xyz/luan/audioplayers/WrappedSoundPool.kt
@@ -119,7 +119,7 @@ class WrappedSoundPool internal constructor(override val playerId: String) : Pla
         throw unsupportedOperation("setDataSource")
     }
 
-    override fun setUrl(url: String, isLocal: Boolean) {
+    override fun setUrl(url: String, isLocal: Boolean, httpHeaders: Map<String, String>) {
         if (this.url != null && this.url == url) {
             return
         }

--- a/feature_parity_table.md
+++ b/feature_parity_table.md
@@ -19,6 +19,7 @@ Note: LLM means Low Latency Mode.
         <tr><td>local file on device</td><td>yes</td><td>yes</td><td>yes</td><td>no</td></tr>
         <tr><td>local asset</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>external URL file</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
+        <tr><td>URL file with http headers</td><td>yes</td><td>no</td><td>no</td><td>no</td></tr>
         <tr><td>external URL stream</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>byte array</td><td>SDK >=23</td><td>not yet</td><td>not yet</td><td>not yet</td></tr>
         <tr><td colspan="5"><strong>Audio Config</strong></td></tr>

--- a/lib/audioplayers.dart
+++ b/lib/audioplayers.dart
@@ -521,12 +521,18 @@ class AudioPlayer {
   Future<int> setUrl(
     String url, {
     bool isLocal: false,
+    Map<String, String> httpHeaders = const {},
     bool respectSilence = false,
   }) {
     isLocal = isLocalUrl(url);
     return _invokeMethod(
       'setUrl',
-      {'url': url, 'isLocal': isLocal, 'respectSilence': respectSilence},
+      {
+        'url': url,
+        'isLocal': isLocal,
+        'httpHeaders': httpHeaders,
+        'respectSilence': respectSilence,
+      },
     );
   }
 


### PR DESCRIPTION
I'm trying to implement passing HTTP headers down to the native media players.

## Android

The Android media player supports passing headers to `setDataSource`. But the situation is a bit more complicated:
The ideal method to call would be 
  ```java
    /**
     * Sets the data source (file-path or http/rtsp URL) to use.
     *
     * @param path the path of the file, or the http/rtsp URL of the stream you want to play
     * @param headers the headers associated with the http request for the stream you want to play
     * @throws IllegalStateException if it is called in an invalid state
     * @hide pending API council
     */
    @UnsupportedAppUsage
    public void setDataSource(String path, Map<String, String> headers)
  ```
(https://github.com/aosp-mirror/platform_frameworks_base/blob/f3d84f44de4209f656d9a5bf4768ecd988cf60b3/media/java/android/media/MediaPlayer.java#L1141)
The problem with this method is that it's not part of the official Android SDK. (note the `@hide` and `@UnsupportedAppUsage`)
It is possible, though not a good idea, to work around that with reflection: https://stackoverflow.com/a/11950581

The alternative method is:
```java
    /**
     * Sets the data source as a content Uri.
     *
     * <p><strong>Note</strong> that the cross domain redirection is allowed by default,
     * but that can be changed with key/value pairs through the headers parameter with
     * "android-allow-cross-domain-redirect" as the key and "0" or "1" as the value to
     * disallow or allow cross domain redirection.
     *
     * @param context the Context to use when resolving the Uri
     * @param uri the Content URI of the data you want to play
     * @param headers the headers to be sent together with the request for the data
     * @throws IllegalStateException if it is called in an invalid state
     */
    public void setDataSource(@NonNull Context context, @NonNull Uri uri,
            @Nullable Map<String, String> headers)
            throws IOException, IllegalArgumentException, SecurityException, IllegalStateException {
        setDataSource(context, uri, headers, null);
    }
```
(https://github.com/aosp-mirror/platform_frameworks_base/blob/f3d84f44de4209f656d9a5bf4768ecd988cf60b3/media/java/android/media/MediaPlayer.java#L1099)

But in this case, we need to pass a `Context` as well. I used `ref.getApplicationContext()`, I hope that's correct.

## iOS

https://stackoverflow.com/a/51797482

## Other platforms
I didn't investigate other platforms yet, as android and iOS are the most important ones for me right now.


fixes #611 