### PR TITLE
Android: synchronous prepare

### DIFF
--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -60,7 +60,7 @@ class WrappedMediaPlayer internal constructor(
     private fun preparePlayer(player: MediaPlayer) {
         player.setVolume(volume.toFloat(), volume.toFloat())
         player.isLooping = releaseMode === ReleaseMode.LOOP
-        player.prepareAsync()
+        player.prepare()
     }
 
     private fun getOrCreatePlayer(): MediaPlayer {


### PR DESCRIPTION
Android:
If you try to `seek` immediately after calling `setUrl`, the following errors are reported:

```
error: MediaPlayer error with what:MEDIA_ERROR_UNKNOWN {extra:-2147483646}
Attempt to perform seekTo in wrong state: mPlayer=0x766f3e8b00, mCurrentState=0
error (-38, 0)
```

The problem lies in [prepareAsync()](https://developer.android.com/reference/android/media/MediaPlayer#prepareAsync()) being used. `setUrl` then reports that the player is ready, but in most cases it's not. Using `prepare()` instead fixes the problem.

I tested it for mp3 files and mp3 urls.

The documentation states:
> For streams, you should call prepareAsync(), which returns immediately, rather than blocking until enough data has been buffered.

I interpret this as: It can still be used for streams, it's just blocking a bit longer until enough data is buffered for playing.

fixes:
#266

Might fix:
#865 #843 