### PR TITLE
Fix the wrong playback status after calling setPlaybackRate

### DIFF
--- a/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
+++ b/packages/audioplayers/android/src/main/kotlin/xyz/luan/audioplayers/WrappedMediaPlayer.kt
@@ -117,6 +117,10 @@ class WrappedMediaPlayer internal constructor(
         val player = this.player ?: return
         if (Build.VERSION.SDK_INT >= 23) {
             player.playbackParams = player.playbackParams.setSpeed(this.rate)
+            if (prepared && !playing) {
+                playing = true
+                ref.handleIsPlaying()
+            }
         }
     }
 


### PR DESCRIPTION
Fix for [#948](https://github.com/luanpotter/audioplayers/issues/948)