### PR TITLE
[WEB] Seek in paused state - makes nothing

### DIFF
--- a/packages/audioplayers/lib/src/audioplayers_web.dart
+++ b/packages/audioplayers/lib/src/audioplayers_web.dart
@@ -103,7 +103,12 @@ class WrappedPlayer {
   }
 
   void seek(int position) {
-    player?.currentTime = position / 1000.0;
+    final seekPosition = position / 1000.0;
+    player?.currentTime = seekPosition;
+
+    if (!isPlaying) {
+      pausedAt = seekPosition;
+    }
   }
 
   void _cancel() {


### PR DESCRIPTION
Fix for audioplayers web.
In case you decided to seek audio during the paused state and then resume - player will play audio from paused point.
This is small PR which fixes this issue.