### PR TITLE
feat(workflows): replace joschi/setup-jdk, add timeout limits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,11 +58,11 @@ jobs:
     steps:
      - uses: actions/checkout@v3
 
-     - name: Setup Java 11
-       uses: joschi/setup-jdk@v2
+     - name: Setup Java 17
+       uses: actions/setup-java@v2
        with:
-         java-version: 'openjdk11'
-         architecture: 'x64'
+         distribution: 'temurin'
+         java-version: '17'
 
      - name: Setup Android SDK
        uses: android-actions/setup-android@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3
@@ -25,6 +26,8 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    
     steps:
      - uses: actions/checkout@v3
 
@@ -54,6 +57,7 @@ jobs:
 
   android:
     runs-on: macOS-latest
+    timeout-minutes: 60
 
     steps:
      - uses: actions/checkout@v3
@@ -104,6 +108,7 @@ jobs:
 
   ios:
     runs-on: macOS-latest
+    timeout-minutes: 60
 
     steps:
      - uses: actions/checkout@v3
@@ -130,6 +135,7 @@ jobs:
 
   macos:
     runs-on: macOS-latest
+    timeout-minutes: 30
 
     steps:
      - uses: actions/checkout@v3
@@ -153,6 +159,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    timeout-minutes: 30
 
     steps:
      - uses: actions/checkout@v3
@@ -170,6 +177,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
See warning on android tests:
```
Notice: The joschi/setup-jdk GitHub Action is deprecated. Please consider switching to the official actions/setup-java action v2 or later which also supports AdoptOpenJDK and its successor Eclipse Temurin: https://github.com/actions/setup-java/tree/v2.5.0#basic
```