### PR TITLE
fix: update platform to 8.0 in podspec.

### DIFF
--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -139,7 +139,7 @@ class WrappedMediaPlayer {
             }
         }
         
-        reference.controlAudioSession()
+        // reference.controlAudioSession()
         reference.onComplete(playerId: playerId)
     }
     

--- a/packages/audioplayers_darwin/ios/audioplayers_darwin.podspec
+++ b/packages/audioplayers_darwin/ios/audioplayers_darwin.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
A compile error  occurs when using .interruptSpokenAudioAndMixWithOthers.