### PR TITLE
reset before setting source in MediaPlayer

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
@@ -48,6 +48,7 @@ class MediaPlayerPlayer(
     }
 
     override fun setSource(source: Source) {
+        reset()
         source.setForMediaPlayer(mediaPlayer)
     }
 


### PR DESCRIPTION
setDataSource is allowed only in the Idle state per https://developer.android.com/reference/android/media/MediaPlayer#state-diagram
the only way to get into the idle state is by calling reset(), which is also safe to do in idle state