### PR TITLE
fix: Make sure onComplete resets the position even when not looping

### DIFF
--- a/packages/audioplayers/example/ios/Podfile.lock
+++ b/packages/audioplayers/example/ios/Podfile.lock
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   audioplayers_darwin: 387322cb364026a1782298c982693b1b6aa9fa1b
-  Flutter: 405776dd0763d7e32a8f989d4e271ca1317d080c
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
 

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -133,10 +133,10 @@ class WrappedMediaPlayer {
         }
 
         seek(time: toCMTime(millis: 0)) {
-            if looping {
+            if self.looping {
                 self.resume()
             } else {
-                isPlaying = false
+                self.isPlaying = false
             }
         }
         

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -131,11 +131,12 @@ class WrappedMediaPlayer {
         if !isPlaying {
             return
         }
-        
-        pause()
-        if looping {
-            seek(time: toCMTime(millis: 0)) {
+
+        seek(time: toCMTime(millis: 0)) {
+            if looping {
                 self.resume()
+            } else {
+                isPlaying = false
             }
         }
         


### PR DESCRIPTION
This makes sure that subsequent `play` calls with the same audio (or simply `resume`) with restart after completion.