### PR TITLE
fix(web): handle infinite duration

### DIFF
--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -52,7 +52,7 @@ class WrappedPlayer {
     }
     Duration toDuration(num jsNum) => Duration(
           milliseconds:
-              (1000 * (jsNum.toString() == 'NaN' ? 0 : jsNum)).round(),
+              (1000 * (jsNum.isNaN || jsNum.isInfinite ? 0 : jsNum)).round(),
         );
 
     final p = player = AudioElement(currentUrl);


### PR DESCRIPTION
If playing streams on web, the duration is an infinite number, which was not considered in the implementation. Therefore it throwed an error: `Unsupported operation: Infinity`