### PR TITLE
fix: ios/macos no longer start audio when calling only setSourceUrl

### DIFF
--- a/packages/audioplayers/example/macos/Podfile.lock
+++ b/packages/audioplayers/example/macos/Podfile.lock
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   audioplayers_darwin: dcad41de4fbd0099cb3749f7ab3b0cb8f70b810c
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -81,10 +81,14 @@ class WrappedMediaPlayer {
     
     func resume() {
         isPlaying = true
-        if #available(iOS 10.0, macOS 10.12, *) {
-            player?.playImmediately(atRate: Float(playbackRate))
-        } else {
-            player?.play()
+        if let player = self.player {
+            configParameters(player: player)
+            if #available(iOS 10.0, macOS 10.12, *) {
+                player.playImmediately(atRate: Float(playbackRate))
+            } else {
+                player.play()
+            }
+            updateDuration()
         }
     }
     
@@ -209,7 +213,6 @@ class WrappedMediaPlayer {
                 let status = playerItem.status
                 Logger.info("player status: %@ change: %@", status, change)
                 
-                // Do something with the status...
                 if status == .readyToPlay {
                     self.updateDuration()
                     completer?()
@@ -228,7 +231,9 @@ class WrappedMediaPlayer {
     }
 
     func configParameters(player: AVPlayer) {
-        player.volume = Float(volume)
-        player.rate = Float(playbackRate)
+        if (isPlaying) {
+            player.volume = Float(volume)
+            player.rate = Float(playbackRate)
+        }
     }
 }


### PR DESCRIPTION
This issue was noted by @Gustl22 on https://github.com/bluefireteam/audioplayers/pull/1128

Unlike other platforms, on iOS rn if `setSourceUrl` is called, the audio then immediatly starts playing after loading. This was because calling set volume / set playback rate actually triggers the audio to start on iOS.

So this:
* only calls configurePlayer during setSource when isPlaying is true
* call configurePlayer on resume

There is also another issue with the test which is the fact that we are not listening for the duration stream on the sources tab. on ios, the duration update when `setSource` happens way too quickly, so when the test switches to the streams tab, the duration stream is not set. So I made it fire _again_ when resume is called. I think that is not a problem. The duration should probably not be a "stream" to begin with as it doesn't change (compare with position stream for example). I think firing the same duration multiple times is perfectly fine and expected given that this is modelled as a stream. In fact there used to be a bug where duration was fired every tick on android (alongside position). So I think this is fine.