### PR TITLE
feat: select decoder automatically on windows

### DIFF
--- a/packages/audioplayers_windows/windows/audio_player.cpp
+++ b/packages/audioplayers_windows/windows/audio_player.cpp
@@ -39,7 +39,7 @@ void AudioPlayer::SetSourceUrl(std::string url) {
         // An application can skip this step and instantiate a custom IMFMediaSource implementation instead.
         winrt::com_ptr<IMFSourceResolver> sourceResolver;
         THROW_IF_FAILED(MFCreateSourceResolver(sourceResolver.put()));
-        constexpr uint32_t sourceResolutionFlags = MF_RESOLUTION_MEDIASOURCE | MF_RESOLUTION_READ;
+        constexpr uint32_t sourceResolutionFlags = MF_RESOLUTION_MEDIASOURCE | MF_RESOLUTION_CONTENT_DOES_NOT_HAVE_TO_MATCH_EXTENSION_OR_MIME_TYPE | MF_RESOLUTION_READ;
         MF_OBJECT_TYPE objectType = {};
         
         winrt::com_ptr<IMFMediaSource> mediaSource;


### PR DESCRIPTION
# Description

This pull request makes audio playback not depend on file extension on Windows by adding the [`MF_RESOLUTION_CONTENT_DOES_NOT_HAVE_TO_MATCH_EXTENSION_OR_MIME_TYPE`][source-resolver-flags] flag.

Before this pr, the file extension of an audio file must be correct. However, it's common that file extension mismatches, or for cached audio files which may not have an extension.

I'm not sure whether this should be a feature or bug fix. On macOS, the player expects whatever extension for playback, but the extension must exist.

[source-resolver-flags]: https://docs.microsoft.com/en-us/windows/win32/medfound/source-resolver-flags

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
