### PR TITLE
fix(linux): emit position event immediately when resume

### DIFF
--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -22,7 +22,7 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *channel)
     // Watch bus messages for one time events
     gst_bus_add_watch(bus, (GstBusFunc) AudioPlayer::OnBusMessage, this);
 
-    // Refresh continuously to emit reoccuring events
+    // Refresh continuously to emit reoccurring events
     g_timeout_add(1000, (GSourceFunc) AudioPlayer::OnRefresh, this);
 }
 
@@ -322,7 +322,9 @@ void AudioPlayer::Resume() {
                 std::string("Unable to set the pipeline to the playing state."));
         return;
     }
-    OnDurationUpdate(); // Update duration when start playing, as no event is emitted elsewhere
+    // Update position and duration when start playing, as no event is emitted elsewhere
+    OnPositionUpdate(); 
+    OnDurationUpdate();
 }
 
 void AudioPlayer::Dispose() {


### PR DESCRIPTION
# Description

Position event is only triggered after an interval (here 1s), now it's triggered once immediately when start playing.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

Tests follow in #1214 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example