### PR TITLE
fix: Fix lowLatency mode not working on Android (#1193)

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -126,7 +126,6 @@ class AudioplayersPlugin : FlutterPlugin {
                 val playerMode = call.enumArgument<PlayerMode>("playerMode")
                     ?: error("playerMode is required")
                 player.playerMode = playerMode
-                return
             }
             "setAudioContext" -> {
                 val audioContext = call.audioContext()


### PR DESCRIPTION
# Description

Low Latency mode does not work on Android.
I think fix #1193 problem.

Here is sample code.

Work fine

```dart
final file = AssetSource("sounds/sound.mp3");
final player = AudioPlayer();
player.setPlayerMode(PlayerMode.lowLatency);
player.play(file);
```

Does not work

```dart
final file = AssetSource("sounds/sound.mp3");
final player = AudioPlayer();
await player.setPlayerMode(PlayerMode.lowLatency);
player.play(file);
```

Does not work

```dart
final file = AssetSource("sounds/sound.mp3");
final player = AudioPlayer();
player.play(file, mode: PlayerMode.lowLatency);
```

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


## Related Issues

fixes #1193
