### PR TITLE
docs: Mention how to treat nuget error on windows

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -8,6 +8,10 @@ In order to install this package, add the [latest version](pub.dev/packages/audi
 
 Audioplayers for Linux (`audioplayers_linux`) is the only platform implementation which relies on additional dependencies. You need to fulfill [these requirements](packages/audioplayers_linux/requirements.md).
 
+On windows audioplayers downloads dependencies using `nuget`.
+In case you encounter error like `Argument cannot be null or empty. Parameter name: primarySources`
+Please run `nuget sources Add -Name nuget.org -Source https://www.nuget.org/api/v2/` to set up dependencies source.
+
 ## AudioPlayer
 
 An `AudioPlayer` instance can play a single audio at a time (think of it as a single boombox). To create it, simply call the constructor:


### PR DESCRIPTION
# Description

This adds mention to Getting Started on how to treat nuget error, if for some reason it is not properly initialized
(it can happen if you use build tools rather than full-fledged visual studio)

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


