### PR TITLE
Added setBalance method

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -92,6 +92,7 @@ class AudioPlayer {
   Future<void> play(
     Source source, {
     double? volume,
+    double? balance,
     AudioContext? ctx,
     Duration? position,
     PlayerMode? mode,
@@ -101,6 +102,9 @@ class AudioPlayer {
     }
     if (volume != null) {
       await setVolume(volume);
+    }
+    if (balance != null) {
+      await setBalance(balance);
     }
     if (ctx != null) {
       await setAudioContext(ctx);
@@ -157,6 +161,15 @@ class AudioPlayer {
   /// Moves the cursor to the desired position.
   Future<void> seek(Duration position) {
     return _platform.seek(playerId, position);
+  }
+
+  /// Sets the stereo balance.
+  ///
+  /// -1 - The left channel is at full volume; the right channel is silent.
+  ///  1 - The right channel is at full volume; the left channel is silent.
+  ///  0 - Both channels are at the same volume.
+  Future<void> setBalance(double balance) {
+    return _platform.setBalance(playerId, balance);
   }
 
   /// Sets the volume (amplitude).

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -13,6 +13,10 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *channel)
         return;
     }
 
+    // Add audiopanorama plugin
+    panorama = gst_element_factory_make("audiopanorama", "audiopanorama");
+    gst_bin_add(GST_BIN(playbin), panorama);
+
     // Setup source options
     g_signal_connect(playbin, "source-setup",
                      G_CALLBACK(AudioPlayer::SourceSetup), &source);
@@ -190,6 +194,16 @@ void AudioPlayer::OnPlaybackEnded() {
     }
 }
 
+void AudioPlayer::SetBalance(float balance) {
+    if (balance > 1.0f) {
+        balance = 1.0f;
+    } else if (balance < 0.0f) {
+        balance = 0.0f;
+    }
+    g_object_set(G_OBJECT(panorama), "method", 1, NULL);
+    g_object_set(G_OBJECT(panorama), "panorama", balance, NULL);
+}
+
 void AudioPlayer::SetLooping(bool isLooping) {
     _isLooping = isLooping;
 }
@@ -331,6 +345,7 @@ void AudioPlayer::Dispose() {
     }
     gst_object_unref(bus);
     gst_object_unref(source);
+    gst_object_unref(panorama);
 
     gst_element_set_state(playbin, GST_STATE_NULL);
     gst_object_unref(playbin);

--- a/packages/audioplayers_linux/linux/audio_player.h
+++ b/packages/audioplayers_linux/linux/audio_player.h
@@ -37,6 +37,8 @@ public:
 
     void Dispose();
 
+    void SetBalance(float balance);
+
     void SetLooping(bool isLooping);
 
     void SetVolume(double volume);
@@ -53,6 +55,7 @@ private:
     // Gst members
     GstElement *playbin;
     GstElement *source;
+    GstElement *panorama;
     GstBus *bus;
 
     bool _isInitialized = false;

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -181,7 +181,14 @@ static void audioplayers_linux_plugin_handle_method_call(
         // TODO check support for low latency mode:
         // https://gstreamer.freedesktop.org/documentation/additional/design/latency.html?gi-language=c
         result = 1;
-    } else {
+    } else if (strcmp(method, "setBalance") == 0) {
+        auto flBalance = fl_value_lookup_string(args, "balance");
+        double balance =
+            flBalance == nullptr ? 0.0f : fl_value_get_float(flBalance);
+        player->SetBalance(balance);
+        result = 1;
+    }
+     else {
         response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
         fl_method_call_respond(method_call, response, nullptr);
         return;

--- a/packages/audioplayers_platform_interface/lib/audioplayers_platform_interface.dart
+++ b/packages/audioplayers_platform_interface/lib/audioplayers_platform_interface.dart
@@ -52,6 +52,13 @@ abstract class AudioplayersPlatform extends PlatformInterface {
   /// Moves the cursor to the desired position.
   Future<void> seek(String playerId, Duration position);
 
+  /// Sets the stereo balance.
+  ///
+  /// -1 - The left channel is at full volume; the right channel is silent.
+  ///  1 - The right channel is at full volume; the left channel is silent.
+  ///  0 - Both channels are at the same volume.
+  Future<void> setBalance(String playerId, double balance);
+
   /// Sets the volume (amplitude).
   ///
   /// 0 is mute and 1 is the max volume. The values between 0 and 1 are linearly

--- a/packages/audioplayers_platform_interface/lib/method_channel_audioplayers_platform.dart
+++ b/packages/audioplayers_platform_interface/lib/method_channel_audioplayers_platform.dart
@@ -70,6 +70,18 @@ class MethodChannelAudioplayersPlatform extends AudioplayersPlatform
   }
 
   @override
+  Future<void> setBalance(
+      String playerId,
+      double balance,
+      ) {
+    return _call(
+      'setBalance',
+      playerId,
+      <String, dynamic>{'balance': balance},
+    );
+  }
+
+  @override
   Future<void> setPlayerMode(
     String playerId,
     PlayerMode playerMode,

--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
@@ -169,6 +169,20 @@ void MediaEngineWrapper::Resume()
     });
 }
 
+void MediaEngineWrapper::SetBalance(double balance)
+{
+    RunSyncInMTA([&]()
+    {
+        auto lock = m_lock.lock();
+        if (m_mediaEngine == nullptr) {
+            return;
+        }
+
+        winrt::com_ptr<IMFMediaEngineEx> mediaEngineEx = m_mediaEngine.as<IMFMediaEngineEx>();
+        THROW_IF_FAILED(mediaEngineEx->SetBalance(balance));
+    });
+}
+
 void MediaEngineWrapper::SetPlaybackRate(double playbackRate)
 {
     RunSyncInMTA([&]()

--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.h
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.h
@@ -47,6 +47,7 @@ class MediaEngineWrapper : public winrt::implements<MediaEngineWrapper, IUnknown
     void Resume();
     void SetPlaybackRate(double playbackRate);
     void SetVolume(float volume);
+    void SetBalance(double balance);
     void SetLooping(bool isLooping);
     void SeekTo(uint64_t timeStamp);
 

--- a/packages/audioplayers_windows/windows/audio_player.cpp
+++ b/packages/audioplayers_windows/windows/audio_player.cpp
@@ -165,6 +165,10 @@ void AudioPlayer::SetPlaybackSpeed(double playbackSpeed) {
     m_mediaEngineWrapper->SetPlaybackRate(playbackSpeed);
 }
 
+void AudioPlayer::SetBalance(double balance) {
+    m_mediaEngineWrapper->SetBalance(balance);
+}
+
 void AudioPlayer::Play() {
     m_mediaEngineWrapper->StartPlayingFrom(m_mediaEngineWrapper->GetMediaTime());
 }

--- a/packages/audioplayers_windows/windows/audio_player.h
+++ b/packages/audioplayers_windows/windows/audio_player.h
@@ -62,6 +62,7 @@ public:
     void SetLooping(bool isLooping);
     void SetVolume(double volume);
     void SetPlaybackSpeed(double playbackSpeed);
+    void SetBalance(double balance);
     void Play();
     void Pause();
     void Resume();

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -199,6 +199,10 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
   } else if (method_call.method_name().compare("setPlayerMode") == 0) {
     // windows doesn't have multiple player modes, so this should no-op
     result->Success(EncodableValue(1));
+  } else if (method_call.method_name().compare("setBalance") == 0) {
+      auto balance = GetArgument<double>("balance", args, 0.0);
+      player->SetBalance(balance);
+      result->Success(EncodableValue(1));
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
# Description

Added method:
```
/// -1 - The left channel is at full volume; the right channel is silent.
///  1 - The right channel is at full volume; the left channel is silent.
///  0 - Both channels are at the same volume.
AudioPlayer.setBalance(double value)
```

## Related Issues
#58
