### PR TITLE
fix(windows): send onDuration event when play/resume

### DIFF
--- a/packages/audioplayers_windows/windows/audio_player.cpp
+++ b/packages/audioplayers_windows/windows/audio_player.cpp
@@ -108,6 +108,17 @@ void AudioPlayer::OnTimeUpdate() {
     }
 }
 
+void AudioPlayer::OnDurationUpdate() {
+    if(this->_channel) {
+        this->_channel->InvokeMethod("audio.onDuration",
+            std::make_unique<flutter::EncodableValue>(
+                flutter::EncodableMap({
+                    {flutter::EncodableValue("playerId"), flutter::EncodableValue(_playerId)},
+                    {flutter::EncodableValue("value"), flutter::EncodableValue((int64_t)m_mediaEngineWrapper->GetDuration() / 10000)}
+                })));
+    }
+}
+
 void AudioPlayer::OnSeekCompleted() {
     if(this->_channel) {
         this->_channel->InvokeMethod("audio.onSeekComplete",
@@ -120,20 +131,8 @@ void AudioPlayer::OnSeekCompleted() {
 }
 
 void AudioPlayer::SendInitialized() {
-    if(this->_channel) {
-        this->_channel->InvokeMethod("audio.onDuration",
-            std::make_unique<flutter::EncodableValue>(
-                flutter::EncodableMap({
-                    {flutter::EncodableValue("playerId"), flutter::EncodableValue(_playerId)},
-                    {flutter::EncodableValue("value"), flutter::EncodableValue((int64_t)m_mediaEngineWrapper->GetDuration() / 10000)}
-                })));
-        this->_channel->InvokeMethod("audio.onCurrentPosition",
-            std::make_unique<flutter::EncodableValue>(
-                flutter::EncodableMap({
-                    {flutter::EncodableValue("playerId"), flutter::EncodableValue(_playerId)},
-                    {flutter::EncodableValue("value"), flutter::EncodableValue((int64_t)m_mediaEngineWrapper->GetMediaTime() / 10000)}
-                })));
-    }
+    OnDurationUpdate();
+    OnTimeUpdate();
 }
 
 void AudioPlayer::Dispose() {
@@ -167,6 +166,7 @@ void AudioPlayer::SetPlaybackSpeed(double playbackSpeed) {
 
 void AudioPlayer::Play() {
     m_mediaEngineWrapper->StartPlayingFrom(m_mediaEngineWrapper->GetMediaTime());
+    OnDurationUpdate();
 }
 
 void AudioPlayer::Pause() {
@@ -175,6 +175,7 @@ void AudioPlayer::Pause() {
 
 void AudioPlayer::Resume() {
     m_mediaEngineWrapper->Resume();
+    OnDurationUpdate();
 }
 
 int64_t AudioPlayer::GetPosition() {

--- a/packages/audioplayers_windows/windows/audio_player.h
+++ b/packages/audioplayers_windows/windows/audio_player.h
@@ -88,6 +88,7 @@ private:
     void OnMediaError(MF_MEDIA_ENGINE_ERR error, HRESULT hr);
     void OnMediaStateChange(media::MediaEngineWrapper::BufferingState bufferingState);
     void OnPlaybackEnded();
+    void OnDurationUpdate();
     void OnTimeUpdate();
     void OnSeekCompleted();
 


### PR DESCRIPTION
# Description

`onDuration` currently only was sent, when source is initialized. Now its also updated, when playing / resuming, so it's consistent with the other platform implementations.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
Tests follow in #1238
Closes #1233 