### PR TITLE
fix(web): bugs from integration tests

### DIFF
--- a/feature_parity_table.md
+++ b/feature_parity_table.md
@@ -50,7 +50,7 @@ Note: LLM means Low Latency Mode.
         <tr><td>resume / pause / stop</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>release / release mode</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes</td></tr>
         <tr><td>volume</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
-        <tr><td>seek</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes</td></tr>
+        <tr><td>seek</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td colspan="7"><strong>Advanced Audio Control Commands</strong></td></tr>
         <tr><td>playback rate</td><td>SDK >= 23</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>duck audio</td><td>yes (except LLM)</td><td>no</td><td>no</td><td>no</td><td>no</td><td>no</td></tr>
@@ -59,10 +59,10 @@ Note: LLM means Low Latency Mode.
         <tr><td>recording active</td><td>not yet</td><td>yes</td><td>no</td><td>no</td><td>no</td><td>no</td></tr>
         <tr><td>playing route</td><td>yes (except LLM)</td><td>yes</td><td>no</td><td>no</td><td>no</td><td>no</td></tr>
         <tr><td colspan="7"><strong>Streams</strong></td></tr>
-        <tr><td>duration event</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes</td></tr>
+        <tr><td>duration event</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>position event</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
-        <tr><td>state event</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes (?)</td></tr>
-        <tr><td>completion event</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes</td></tr>
+        <tr><td>state event</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes (?)</td></tr>
+        <tr><td>completion event</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td></tr>
         <tr><td>error event</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>yes</td><td>yes</td></tr>
     </tbody>
 </table>

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -20,6 +20,8 @@ class WrappedPlayer {
   StreamSubscription? playerTimeUpdateSubscription;
   StreamSubscription? playerEndedSubscription;
   StreamSubscription? playerLoadedDataSubscription;
+  StreamSubscription? playerPlaySubscription;
+  StreamSubscription? playerSeekedSubscription;
 
   WrappedPlayer(this.playerId, this.streamsInterface);
 
@@ -59,11 +61,17 @@ class WrappedPlayer {
     p.loop = shouldLoop();
     p.volume = currentVolume;
     p.playbackRate = currentPlaybackRate;
-    playerLoadedDataSubscription = p.onLoadedData.listen((event) {
+    playerPlaySubscription = p.onPlay.listen((_) {
+      streamsInterface.emitDuration(playerId, toDuration(p.duration));
+    });
+    playerLoadedDataSubscription = p.onLoadedData.listen((_) {
       streamsInterface.emitDuration(playerId, toDuration(p.duration));
     });
     playerTimeUpdateSubscription = p.onTimeUpdate.listen((_) {
       streamsInterface.emitPosition(playerId, toDuration(p.currentTime));
+    });
+    playerSeekedSubscription = p.onSeeked.listen((_) {
+      streamsInterface.emitSeekComplete(playerId);
     });
     playerEndedSubscription = p.onEnded.listen((_) {
       pausedAt = 0;
@@ -90,6 +98,10 @@ class WrappedPlayer {
     playerTimeUpdateSubscription = null;
     playerEndedSubscription?.cancel();
     playerEndedSubscription = null;
+    playerSeekedSubscription?.cancel();
+    playerSeekedSubscription = null;
+    playerPlaySubscription?.cancel();
+    playerPlaySubscription = null;
   }
 
   void start(double position) {
@@ -110,7 +122,8 @@ class WrappedPlayer {
 
   void pause() {
     pausedAt = player?.currentTime as double?;
-    _cancel();
+    isPlaying = false;
+    player?.pause();
   }
 
   void stop() {


### PR DESCRIPTION
* emit duration if start playing
* emit seek completed event
* avoid resetting player if pausing in release mode

# Description

- Enable seek and duration events in web implementation.
- Fix bug, where player is reset to null on pause in release mode.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

Closes #1023 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
