### PR TITLE
fix(web): handle infinite value on getDuration for live streams

### DIFF
--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -6,7 +6,7 @@ import 'package:audioplayers_platform_interface/api/player_mode.dart';
 import 'package:audioplayers_platform_interface/api/release_mode.dart';
 import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
 import 'package:audioplayers_platform_interface/streams_interface.dart';
-import 'package:audioplayers_web/util.dart';
+import 'package:audioplayers_web/num_extension.dart';
 import 'package:audioplayers_web/wrapped_player.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -34,11 +34,11 @@ class AudioplayersPlugin extends AudioplayersPlatform with StreamsInterface {
 
   @override
   Future<int?> getDuration(String playerId) async {
-    final duration = getOrCreatePlayer(playerId).player?.duration;
-    if (duration == null) {
+    final jsDuration = getOrCreatePlayer(playerId).player?.duration;
+    if (jsDuration == null) {
       return null;
     }
-    return toDuration(duration).inMilliseconds;
+    return jsDuration.fromSecondsToDuration().inMilliseconds;
   }
 
   @override

--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -6,6 +6,7 @@ import 'package:audioplayers_platform_interface/api/player_mode.dart';
 import 'package:audioplayers_platform_interface/api/release_mode.dart';
 import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
 import 'package:audioplayers_platform_interface/streams_interface.dart';
+import 'package:audioplayers_web/util.dart';
 import 'package:audioplayers_web/wrapped_player.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -37,7 +38,7 @@ class AudioplayersPlugin extends AudioplayersPlatform with StreamsInterface {
     if (duration == null) {
       return null;
     }
-    return (duration * 1000).toInt();
+    return toDuration(duration).inMilliseconds;
   }
 
   @override

--- a/packages/audioplayers_web/lib/num_extension.dart
+++ b/packages/audioplayers_web/lib/num_extension.dart
@@ -1,0 +1,6 @@
+extension NumExtension on num {
+  /// converts num to the duration, if in seconds
+  Duration fromSecondsToDuration() => Duration(
+        seconds: (isNaN || isInfinite ? 0 : this).round(),
+      );
+}

--- a/packages/audioplayers_web/lib/num_extension.dart
+++ b/packages/audioplayers_web/lib/num_extension.dart
@@ -1,5 +1,5 @@
 extension NumExtension on num {
-  /// converts num to the duration, if in seconds
+  /// Converts [num] (expected in seconds) to the duration.
   Duration fromSecondsToDuration() => Duration(
         seconds: (isNaN || isInfinite ? 0 : this).round(),
       );

--- a/packages/audioplayers_web/lib/util.dart
+++ b/packages/audioplayers_web/lib/util.dart
@@ -1,0 +1,4 @@
+/// [jsNum] the duration in seconds
+Duration toDuration(num jsNum) => Duration(
+      seconds: (jsNum.isNaN || jsNum.isInfinite ? 0 : jsNum).round(),
+    );

--- a/packages/audioplayers_web/lib/util.dart
+++ b/packages/audioplayers_web/lib/util.dart
@@ -1,4 +1,0 @@
-/// [jsNum] the duration in seconds
-Duration toDuration(num jsNum) => Duration(
-      seconds: (jsNum.isNaN || jsNum.isInfinite ? 0 : jsNum).round(),
-    );

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -3,7 +3,7 @@ import 'dart:html';
 
 import 'package:audioplayers_platform_interface/api/release_mode.dart';
 import 'package:audioplayers_platform_interface/streams_interface.dart';
-import 'package:audioplayers_web/util.dart';
+import 'package:audioplayers_web/num_extension.dart';
 
 class WrappedPlayer {
   final String playerId;
@@ -62,13 +62,22 @@ class WrappedPlayer {
     p.volume = currentVolume;
     p.playbackRate = currentPlaybackRate;
     playerPlaySubscription = p.onPlay.listen((_) {
-      streamsInterface.emitDuration(playerId, toDuration(p.duration));
+      streamsInterface.emitDuration(
+        playerId,
+        p.duration.fromSecondsToDuration(),
+      );
     });
     playerLoadedDataSubscription = p.onLoadedData.listen((_) {
-      streamsInterface.emitDuration(playerId, toDuration(p.duration));
+      streamsInterface.emitDuration(
+        playerId,
+        p.duration.fromSecondsToDuration(),
+      );
     });
     playerTimeUpdateSubscription = p.onTimeUpdate.listen((_) {
-      streamsInterface.emitPosition(playerId, toDuration(p.currentTime));
+      streamsInterface.emitPosition(
+        playerId,
+        p.duration.fromSecondsToDuration(),
+      );
     });
     playerSeekedSubscription = p.onSeeked.listen((_) {
       streamsInterface.emitSeekComplete(playerId);

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -3,6 +3,7 @@ import 'dart:html';
 
 import 'package:audioplayers_platform_interface/api/release_mode.dart';
 import 'package:audioplayers_platform_interface/streams_interface.dart';
+import 'package:audioplayers_web/util.dart';
 
 class WrappedPlayer {
   final String playerId;
@@ -55,10 +56,6 @@ class WrappedPlayer {
     if (currentUrl == null) {
       return;
     }
-    Duration toDuration(num jsNum) => Duration(
-          milliseconds:
-              (1000 * (jsNum.isNaN || jsNum.isInfinite ? 0 : jsNum)).round(),
-        );
 
     final p = player = AudioElement(currentUrl);
     p.loop = shouldLoop();

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -76,7 +76,7 @@ class WrappedPlayer {
     playerTimeUpdateSubscription = p.onTimeUpdate.listen((_) {
       streamsInterface.emitPosition(
         playerId,
-        p.duration.fromSecondsToDuration(),
+        p.currentTime.fromSecondsToDuration(),
       );
     });
     playerSeekedSubscription = p.onSeeked.listen((_) {


### PR DESCRIPTION
# Description

Like on #1192, if calling `getDuration` an infinite value is returned, which isn't handled by the web implementation.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example] (follwing in #1284 ).

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
