### PR TITLE
fix(android): Avoid ConcurrentModificationException

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -17,6 +17,7 @@ import xyz.luan.audioplayers.player.WrappedPlayer
 import xyz.luan.audioplayers.source.BytesSource
 import xyz.luan.audioplayers.source.UrlSource
 import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentMap
 
 typealias FlutterHandler = (call: MethodCall, response: MethodChannel.Result) -> Unit
 
@@ -189,7 +190,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
     }
 
     private class UpdateRunnable(
-        mediaPlayers: Map<String, WrappedPlayer>,
+        mediaPlayers: ConcurrentMap<String, WrappedPlayer>,
         channel: MethodChannel,
         handler: Handler,
         updateCallback: IUpdateCallback,
@@ -209,7 +210,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                 return
             }
             var isAnyPlaying = false
-            for (player in mediaPlayers.values.toList()) {
+            for (player in mediaPlayers.values) {
                 if (!player.isActuallyPlaying()) {
                     continue
                 }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -209,9 +209,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                 return
             }
             var isAnyPlaying = false
-            val iterator = mediaPlayers.values.iterator()
-            while (iterator.hasNext()) {
-                val player = iterator.next()
+            while (player in mediaPlayers.values.toList()) {
                 if (!player.isActuallyPlaying()) {
                     continue
                 }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -17,6 +17,7 @@ import xyz.luan.audioplayers.player.WrappedPlayer
 import xyz.luan.audioplayers.source.BytesSource
 import xyz.luan.audioplayers.source.UrlSource
 import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
 typealias FlutterHandler = (call: MethodCall, response: MethodChannel.Result) -> Unit
@@ -28,7 +29,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
     private lateinit var globalChannel: MethodChannel
     private lateinit var context: Context
 
-    private val players = mutableMapOf<String, WrappedPlayer>()
+    private val players = ConcurrentHashMap<String, WrappedPlayer>()
     private val handler = Handler(Looper.getMainLooper())
     private var updateRunnable: Runnable? = null
 

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -209,7 +209,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                 return
             }
             var isAnyPlaying = false
-            while (player in mediaPlayers.values.toList()) {
+            for (player in mediaPlayers.values.toList()) {
                 if (!player.isActuallyPlaying()) {
                     continue
                 }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -209,7 +209,9 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                 return
             }
             var isAnyPlaying = false
-            for (player in mediaPlayers.values) {
+            val iterator = mediaPlayers.values.iterator()
+            while (iterator.hasNext()) {
+                val player = iterator.next()
                 if (!player.isActuallyPlaying()) {
                     continue
                 }


### PR DESCRIPTION
# Description

When playing a lot of sounds simultaneously apparently some users get `ConcurrentModificationException` in this for loop.
The best solution would be to be able to use a `ConcurrentHashMap`, but I don't know how to do that in here.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #1274 

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
