### PR TITLE
fix: Duration precision on Windows

### DIFF
--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -102,13 +102,13 @@ Future<void> testStreamsTab(
 extension StreamWidgetTester on WidgetTester {
   // Precision for duration & position:
   // Android: two tenth of a second
-  // Windows: second
+  // Windows: millisecond
   // Linux: second
   // Web: second
 
   // Update interval for duration & position:
   // Android: two tenth of a second
-  // Windows: second
+  // Windows: ~250ms
   // Linux: second
   // Web: second
 

--- a/packages/audioplayers_windows/windows/MediaFoundationHelpers.h
+++ b/packages/audioplayers_windows/windows/MediaFoundationHelpers.h
@@ -148,6 +148,8 @@ constexpr uint64_t c_hnsPerSecond = 10000000;
 template<typename SecondsT>
 inline uint64_t ConvertSecondsToHns(SecondsT seconds)
 {
+    if (isinf(seconds))
+        return 0;
     return static_cast<uint64_t>(seconds * c_hnsPerSecond);
 }
 

--- a/packages/audioplayers_windows/windows/MediaFoundationHelpers.h
+++ b/packages/audioplayers_windows/windows/MediaFoundationHelpers.h
@@ -148,7 +148,7 @@ constexpr uint64_t c_hnsPerSecond = 10000000;
 template<typename SecondsT>
 inline uint64_t ConvertSecondsToHns(SecondsT seconds)
 {
-    return static_cast<uint64_t>(seconds) * c_hnsPerSecond;
+    return static_cast<uint64_t>(seconds * c_hnsPerSecond);
 }
 
 template<typename HnsT>


### PR DESCRIPTION
# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

Fixes the precision of `seek`, `getCurrentPosition`, `getDuration` and their streams on windows. Currently, due to a casting bug, the precision is 1 second.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

None

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
