### PR TITLE
docs: Fix repos and homepages on pubspecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AudioPlayers
 
-[![Pub](https://img.shields.io/pub/v/audioplayers.svg?style=popout&include_prereleases)](https://pub.dartlang.org/packages/audioplayers) [![Build Status](https://github.com/luanpotter/audioplayers/workflows/build/badge.svg?branch=main)](https://github.com/luanpotter/audioplayers/actions?query=workflow%3A"build"+branch%3Amain) [![Discord](https://img.shields.io/discord/509714518008528896.svg)](https://discord.gg/pxrBmy4) [![Melos](https://img.shields.io/badge/maintained%20with-melos-f700ff.svg)](https://github.com/invertase/melos)
+[![Pub](https://img.shields.io/pub/v/audioplayers.svg?style=popout&include_prereleases)](https://pub.dartlang.org/packages/audioplayers) [![Build Status](https://github.com/bluefireteam/audioplayers/workflows/build/badge.svg?branch=main)](https://github.com/bluefireteam/audioplayers/actions?query=workflow%3A"build"+branch%3Amain) [![Discord](https://img.shields.io/discord/509714518008528896.svg)](https://discord.gg/pxrBmy4) [![Melos](https://img.shields.io/badge/maintained%20with-melos-f700ff.svg)](https://github.com/invertase/melos)
 
 A Flutter plugin to play multiple simultaneously audio files, works for Android, iOS, Linux, macOS, Windows, and web.
 

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers
 description: A Flutter plugin to play multiple audio files simultaneously
 version: 1.1.1
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers
 
 flutter:
   plugin:

--- a/packages/audioplayers_android/pubspec.yaml
+++ b/packages/audioplayers_android/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_android
 description: Android implementation of audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 1.1.1
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_android
 
 flutter:
   plugin:

--- a/packages/audioplayers_darwin/pubspec.yaml
+++ b/packages/audioplayers_darwin/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_darwin
 description: iOS and macOS implementation of audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 1.0.3
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_darwin
 
 flutter:
   plugin:

--- a/packages/audioplayers_linux/pubspec.yaml
+++ b/packages/audioplayers_linux/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_linux
 description: Linux implementation of audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 1.0.1
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_linux
 
 flutter:
   plugin:

--- a/packages/audioplayers_platform_interface/pubspec.yaml
+++ b/packages/audioplayers_platform_interface/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_platform_interface
 description: The platform interface for audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 2.0.0
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_platform_interface
 
 dependencies:
   flutter:

--- a/packages/audioplayers_web/pubspec.yaml
+++ b/packages/audioplayers_web/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_web
 description: Web implementation of audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 2.0.1
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_web
 
 flutter:
   plugin:

--- a/packages/audioplayers_windows/pubspec.yaml
+++ b/packages/audioplayers_windows/pubspec.yaml
@@ -1,7 +1,8 @@
 name: audioplayers_windows
 description: Windows implementation of audioplayers, a Flutter plugin to play multiple audio files simultaneously
 version: 1.1.0
-homepage: https://github.com/luanpotter/audioplayers
+homepage: https://github.com/bluefireteam/audioplayers
+repository: https://github.com/bluefireteam/audioplayers/tree/master/packages/audioplayers_windows
 
 flutter:
   plugin:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -56,7 +56,7 @@ The remote URL must be accessible and not be a redirect. If it's not an audio fi
 
 **Warning**: If you are having any sort of build issues, you must read this first.
 
-Our [CI](https://github.com/luanpotter/audioplayers/blob/master/.github/workflows/build.yaml) builds our example app using audioplayers for Android, iOS, Linux, macOS, Windows, and web. So if the build is passing, any build errors (from android/ios sdk, gradle, java, kotlin, cocoa pods, swift, flutter, etc) is not a global issue and likely is something on your setup.
+Our [CI](https://github.com/bluefireteam/audioplayers/blob/master/.github/workflows/build.yaml) builds our example app using audioplayers for Android, iOS, Linux, macOS, Windows, and web. So if the build is passing, any build errors (from android/ios sdk, gradle, java, kotlin, cocoa pods, swift, flutter, etc) is not a global issue and likely is something on your setup.
 
 Before opening an issue, you **must** try these steps:
 
@@ -91,7 +91,7 @@ Or on XCode you can add it as a capability; more details [here](https://develope
 
 ## Audio Stream Issues
 
-One of the know reasons for streams not playing is that the stream is being gziped by the server, as described [here](https://github.com/luanpotter/audioplayers/issues/183).
+One of the know reasons for streams not playing is that the stream is being gziped by the server, as described [here](https://github.com/bluefireteam/audioplayers/issues/183).
 
 ## Gapless Looping
 


### PR DESCRIPTION
# Description

As pointed out to me by boraizzet, if you go to our [pub page](https://pub.dev/packages/audioplayers/example), this link is broken:

![image](https://user-images.githubusercontent.com/882703/208792040-9e12a6c6-1ee7-443c-977f-316ff35b7d05.png)

Because it assumes the code is in the root of the repo (`https://github.com/luanpotter/audioplayers/blob/master/example/lib/main.dart`). That is controlled by the `repository` entry on pubpsec, which we don't even have -- so i falls back to `homepage`.

So this PR fixes a few issues with our pubspec setup regarding the repo:

* fixes the old repo url to the new bluefire one
* add both homepage and repository as they are different things
* homepage still points to the root of the repo for the nice readme -- for now
* repository points to the actually repository folder inside the `blob/master`

This is in line with how other mono-repos do it, [for example firebase_core](https://github.com/firebase/flutterfire/blob/master/packages/firebase_core/firebase_core/pubspec.yaml)

Note that each package has a symlink for the readme so that should work fine.

I believe this fixes all the problems, but please lmk if it makes sense.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
