### PR TITLE
fix: [Discussion] Add try-catch to avoid IllegalStateException when calling player.isPlaying on Android media player

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
@@ -31,7 +31,13 @@ class MediaPlayerPlayer(
     }
 
     override fun isActuallyPlaying(): Boolean {
-        return mediaPlayer.isPlaying
+        return try {
+            mediaPlayer.isPlaying
+        } catch (ex: IllegalStateException) {
+            // isPlaying throws IllegalStateException if the player is not ready or released
+            // that just means it is _not_ playing
+            false
+        }
     }
 
     override fun setVolume(volume: Float) {


### PR DESCRIPTION
# Description

Add try-catch to avoid IllegalStateException when calling player.isPlaying on Android media player

See issues like #1150 and #1331 for some examples.

For examples of this issue. Though sometimes the exception is thrown on other methods used on the wrong time.

This is definitely a band-aid solution. The goal of WrappedPlayer is to abstract away all the insane fragility of android's default media player by doing its own state control.

This could help reduce some errors, but might as well be hinding some async/thread/racing conditions and such.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
