### PR TITLE
fix!: remove unused `defaultToSpeaker` in `AudioContextIOS` and replace with `AVAudioSessionOptions.defaultToSpeaker`

### DIFF
--- a/packages/audioplayers/example/lib/tabs/audio_context.dart
+++ b/packages/audioplayers/example/lib/tabs/audio_context.dart
@@ -117,7 +117,6 @@ class _AudioContextTabState extends State<AudioContextTab>
     final i = config.buildIOS();
     return Column(
       children: [
-        Text('defaultToSpeaker: ${i.defaultToSpeaker}'),
         Text('category: ${i.category}'),
         Text('options: ${i.options}'),
       ],

--- a/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
+++ b/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
@@ -3,22 +3,18 @@ import MediaPlayer
 struct AudioContext {
     let category: AVAudioSession.Category
     let options: [AVAudioSession.CategoryOptions]
-    let defaultToSpeaker: Bool
     
     init() {
         self.category = .playAndRecord
         self.options = [.mixWithOthers]
-        self.defaultToSpeaker = false
     }
     
     init(
         category: AVAudioSession.Category,
-        options: [AVAudioSession.CategoryOptions],
-        defaultToSpeaker: Bool
+        options: [AVAudioSession.CategoryOptions]
     ) {
         self.category = category
         self.options = options
-        self.defaultToSpeaker = defaultToSpeaker
     }
     
     func activateAudioSession(
@@ -60,15 +56,9 @@ struct AudioContext {
             return nil
         }
         
-        guard let defaultToSpeaker = args["defaultToSpeaker"] as! Bool? else {
-            Logger.error("Null value received for defaultToSpeaker")
-            return nil
-        }
-        
         return AudioContext(
             category: category,
-            options: options,
-            defaultToSpeaker: defaultToSpeaker
+            options: options
         )
     }
 

--- a/packages/audioplayers_platform_interface/lib/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/api/audio_context_config.dart
@@ -118,12 +118,12 @@ class AudioContextConfig {
       validateIOS();
     }
     return AudioContextIOS(
-      defaultToSpeaker: forceSpeaker,
       category: respectSilence
           ? AVAudioSessionCategory.ambient
           : AVAudioSessionCategory.playback,
       options: [AVAudioSessionOptions.mixWithOthers] +
-          (duckAudio ? [AVAudioSessionOptions.duckOthers] : []),
+          (duckAudio ? [AVAudioSessionOptions.duckOthers] : []) +
+          (forceSpeaker ? [AVAudioSessionOptions.defaultToSpeaker] : []),
     );
   }
 
@@ -141,9 +141,9 @@ class AudioContext {
   final AudioContextAndroid android;
   final AudioContextIOS iOS;
 
-  AudioContext({
-    required this.android,
-    required this.iOS,
+  const AudioContext({
+    this.android = const AudioContextAndroid(),
+    this.iOS = const AudioContextIOS(),
   });
 
   AudioContext copy({
@@ -178,12 +178,12 @@ class AudioContextAndroid {
   final AndroidUsageType usageType;
   final AndroidAudioFocus? audioFocus;
 
-  AudioContextAndroid({
-    required this.isSpeakerphoneOn,
-    required this.stayAwake,
-    required this.contentType,
-    required this.usageType,
-    required this.audioFocus,
+  const AudioContextAndroid({
+    this.isSpeakerphoneOn = true,
+    this.stayAwake = true,
+    this.contentType = AndroidContentType.music,
+    this.usageType = AndroidUsageType.media,
+    this.audioFocus = AndroidAudioFocus.gain,
   });
 
   AudioContextAndroid copy({
@@ -214,23 +214,22 @@ class AudioContextAndroid {
 }
 
 class AudioContextIOS {
-  final bool defaultToSpeaker;
   final AVAudioSessionCategory category;
   final List<AVAudioSessionOptions> options;
 
-  AudioContextIOS({
-    required this.defaultToSpeaker,
-    required this.category,
-    required this.options,
+  const AudioContextIOS({
+    this.category = AVAudioSessionCategory.playback,
+    this.options = const [
+      AVAudioSessionOptions.mixWithOthers,
+      AVAudioSessionOptions.defaultToSpeaker
+    ],
   });
 
   AudioContextIOS copy({
-    bool? defaultToSpeaker,
     AVAudioSessionCategory? category,
     List<AVAudioSessionOptions>? options,
   }) {
     return AudioContextIOS(
-      defaultToSpeaker: defaultToSpeaker ?? this.defaultToSpeaker,
       category: category ?? this.category,
       options: options ?? this.options,
     );
@@ -238,7 +237,6 @@ class AudioContextIOS {
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'defaultToSpeaker': defaultToSpeaker,
       'category': category.name,
       'options': options.map((e) => e.name).toList(),
     };

--- a/packages/audioplayers_platform_interface/lib/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/api/audio_context_config.dart
@@ -103,7 +103,6 @@ class AudioContextConfig {
     return AudioContextAndroid(
       isSpeakerphoneOn: forceSpeaker,
       stayAwake: stayAwake,
-      contentType: AndroidContentType.music,
       usageType: respectSilence
           ? AndroidUsageType.notificationRingtone
           : AndroidUsageType.media,


### PR DESCRIPTION
# Description

- The parameter `defaultToSpeaker` was not used in `AudioContextIOS`. Instead `option: [AVAudioSessionOptions.defaultToSpeaker]` should be used
- `AudioContext` now has default configurations for `iOS` and `android`. Nevertheless it is recommended to set the config via `AudioContextConfig.build()`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

 ### Migration instructions

Old: 
```dart
  AudioPlayer.global.setGlobalAudioContext(
    AudioContext(
      iOS: AudioContextIOS(
        defaultToSpeaker: true,
        category: AVAudioSessionCategory.playback,
        options: [AVAudioSessionOptions.mixWithOthers],
      ),
      android: AudioContextAndroid(
        isSpeakerphoneOn: true,
        stayAwake: true,
        contentType: AndroidContentType.music,
        usageType: AndroidUsageType.media,
        audioFocus: AndroidAudioFocus.gain,
      ),
    ),
  );
```


New:

```dart
  AudioPlayer.global.setGlobalAudioContext(
    AudioContext(
      iOS: AudioContextIOS(
        category: AVAudioSessionCategory.playback,
        options: [
          AVAudioSessionOptions.mixWithOthers,
          AVAudioSessionOptions.defaultToSpeaker,
        ],
      ),
    ),
  );
```

Instead of setting `defaultToSpeaker` in `AudioContextIOS`, use the `option: [AVAudioSessionOptions.defaultToSpeaker]`.

## Related Issues

Closes #1194 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
