### PR TITLE
fix(web): Error: "@staticInterop" classes should not contain any generative constructors

### DIFF
--- a/packages/audioplayers_web/lib/web_audio_js.dart
+++ b/packages/audioplayers_web/lib/web_audio_js.dart
@@ -5,7 +5,7 @@ import 'package:js/js.dart';
 @JS('AudioContext')
 @staticInterop
 class JsAudioContext {
-  external JsAudioContext();
+  external factory JsAudioContext();
 }
 
 extension JsAudioContextExtension on JsAudioContext {
@@ -21,7 +21,7 @@ extension JsAudioContextExtension on JsAudioContext {
 @JS()
 @staticInterop
 abstract class AudioNode {
-  external AudioNode();
+  external factory AudioNode();
 }
 
 extension AudioNodeExtension on AudioNode {
@@ -31,7 +31,7 @@ extension AudioNodeExtension on AudioNode {
 @JS()
 @staticInterop
 class AudioParam {
-  external AudioParam();
+  external factory AudioParam();
 }
 
 extension AudioParamExtension on AudioParam {
@@ -41,7 +41,7 @@ extension AudioParamExtension on AudioParam {
 @JS()
 @staticInterop
 class StereoPannerNode implements AudioNode {
-  external StereoPannerNode();
+  external factory StereoPannerNode();
 }
 
 extension StereoPannerNodeExtension on StereoPannerNode {
@@ -51,5 +51,5 @@ extension StereoPannerNodeExtension on StereoPannerNode {
 @JS()
 @staticInterop
 class MediaElementAudioSourceNode implements AudioNode {
-  external MediaElementAudioSourceNode();
+  external factory MediaElementAudioSourceNode();
 }


### PR DESCRIPTION
# Description

This PR fixed a build error described here: https://github.com/bluefireteam/audioplayers/issues/1378

It changes all `external ...` with `external factory` in packages/audioplayers_web/lib/web_audio_js.dart, as described in this issue https://github.com/flutter/flutter/issues/115988

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

Note: only minor changes that don't require updating tests, docs or example

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Fixes #1378

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
