### PR TITLE
fix(iOS): Default to speaker instead of earpiece on iOS

### DIFF
--- a/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
+++ b/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
@@ -6,9 +6,9 @@ struct AudioContext {
     
     init() {
         self.category = .playAndRecord
-        self.options = [.mixWithOthers]
+        self.options = [.mixWithOthers, .defaultToSpeaker]
     }
-    
+
     init(
         category: AVAudioSession.Category,
         options: [AVAudioSession.CategoryOptions]


### PR DESCRIPTION
# Description

I haven't tried this on a real device so it's quite a shot in the dark.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

Closes #1194 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
