### PR TITLE
test: print times on failure, increase timeout for PlayerState.completed

### DIFF
--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -8,6 +8,7 @@ import 'package:integration_test/integration_test.dart';
 
 import 'platform_features.dart';
 import 'source_test_data.dart';
+import 'test_utils.dart';
 
 void main() {
   final features = PlatformFeatures.instance();
@@ -79,7 +80,7 @@ void main() {
           if (td.isLiveStream || td.duration > const Duration(seconds: 10)) {
             await tester.pump();
             final position = await players[i].getCurrentPosition();
-            printOnFailure('Test position: $td');
+            printWithTimeOnFailure('Test position: $td');
             expect(position, greaterThan(Duration.zero));
           }
           await players[i].stop();
@@ -104,7 +105,7 @@ void main() {
         if (td.isLiveStream || td.duration > const Duration(seconds: 10)) {
           await tester.pump();
           final position = await player.getCurrentPosition();
-          printOnFailure('Test position: $td');
+          printWithTimeOnFailure('Test position: $td');
           expect(position, greaterThan(Duration.zero));
         }
         await player.stop();

--- a/packages/audioplayers/example/integration_test/tabs/context_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/context_tab.dart
@@ -2,13 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../platform_features.dart';
 import '../source_test_data.dart';
+import '../test_utils.dart';
 
 Future<void> testContextTab(
   WidgetTester tester,
   AppSourceTestData audioSourceTestData,
   PlatformFeatures features,
 ) async {
-  printOnFailure('Test Context Tab');
+  printWithTimeOnFailure('Test Context Tab');
   // Audio context
   // TODO(Gustl22): test generic flags
   // await tester.tap(find.byKey(const Key('audioContextTab')));

--- a/packages/audioplayers/example/integration_test/tabs/controls_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/controls_tab.dart
@@ -13,7 +13,7 @@ Future<void> testControlsTab(
   AppSourceTestData audioSourceTestData,
   PlatformFeatures features,
 ) async {
-  printOnFailure('Test Controls Tab');
+  printWithTimeOnFailure('Test Controls Tab');
   await tester.tap(find.byKey(const Key('controlsTab')));
   await tester.pumpAndSettle();
 
@@ -146,7 +146,7 @@ extension ControlsWidgetTester on WidgetTester {
     String volume, {
     Duration timeout = const Duration(seconds: 1),
   }) async {
-    printOnFailure('Test Volume: $volume');
+    printWithTimeOnFailure('Test Volume: $volume');
     await scrollToAndTap(Key('control-volume-$volume'));
     await resume();
     // TODO(Gustl22): get volume from native implementation
@@ -158,7 +158,7 @@ extension ControlsWidgetTester on WidgetTester {
     String balance, {
     Duration timeout = const Duration(seconds: 1),
   }) async {
-    printOnFailure('Test Balance: $balance');
+    printWithTimeOnFailure('Test Balance: $balance');
     await scrollToAndTap(Key('control-balance-$balance'));
     await resume();
     // TODO(novikov): get balance from native implementation
@@ -170,7 +170,7 @@ extension ControlsWidgetTester on WidgetTester {
     String rate, {
     Duration timeout = const Duration(seconds: 2),
   }) async {
-    printOnFailure('Test Rate: $rate');
+    printWithTimeOnFailure('Test Rate: $rate');
     await scrollToAndTap(Key('control-rate-$rate'));
     await resume();
     // TODO(Gustl22): get rate from native implementation
@@ -182,7 +182,7 @@ extension ControlsWidgetTester on WidgetTester {
     String seek, {
     bool isResume = true,
   }) async {
-    printOnFailure('Test Seek: $seek');
+    printWithTimeOnFailure('Test Seek: $seek');
     final st = StackTrace.current.toString();
 
     await scrollToAndTap(Key('control-seek-$seek'));
@@ -195,7 +195,7 @@ extension ControlsWidgetTester on WidgetTester {
   }
 
   Future<void> testPlayerMode(PlayerMode mode) async {
-    printOnFailure('Test Player Mode: ${mode.name}');
+    printWithTimeOnFailure('Test Player Mode: ${mode.name}');
     final st = StackTrace.current.toString();
 
     await scrollToAndTap(Key('control-player-mode-${mode.name}'));
@@ -209,7 +209,7 @@ extension ControlsWidgetTester on WidgetTester {
   }
 
   Future<void> testReleaseMode(ReleaseMode mode, {bool isResume = true}) async {
-    printOnFailure('Test Release Mode: ${mode.name}');
+    printWithTimeOnFailure('Test Release Mode: ${mode.name}');
     final st = StackTrace.current.toString();
 
     await scrollToAndTap(Key('control-release-mode-${mode.name}'));

--- a/packages/audioplayers/example/integration_test/tabs/logs_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/logs_tab.dart
@@ -2,13 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../platform_features.dart';
 import '../source_test_data.dart';
+import '../test_utils.dart';
 
 Future<void> testLogsTab(
   WidgetTester tester,
   AppSourceTestData audioSourceTestData,
   PlatformFeatures features,
 ) async {
-  printOnFailure('Test Logs Tab');
+  printWithTimeOnFailure('Test Logs Tab');
   // TODO(Gustl22): may test logs
   // await tester.tap(find.byKey(const Key('loggerTab')));
   // await tester.pumpAndSettle();

--- a/packages/audioplayers/example/integration_test/tabs/properties.dart
+++ b/packages/audioplayers/example/integration_test/tabs/properties.dart
@@ -9,7 +9,7 @@ extension PropertiesWidgetTester on WidgetTester {
     Duration duration, {
     Duration timeout = const Duration(seconds: 4),
   }) async {
-    printOnFailure('Test Duration: $duration');
+    printWithTimeOnFailure('Test Duration: $duration');
     final st = StackTrace.current.toString();
     await waitFor(
       () async {
@@ -30,7 +30,7 @@ extension PropertiesWidgetTester on WidgetTester {
     Matcher Function(Duration) matcher = equals,
     Duration timeout = const Duration(seconds: 4),
   }) async {
-    printOnFailure('Test Position: $position');
+    printWithTimeOnFailure('Test Position: $position');
     final st = StackTrace.current.toString();
     await waitFor(
       () async {
@@ -50,7 +50,7 @@ extension PropertiesWidgetTester on WidgetTester {
     PlayerState playerState, {
     Duration timeout = const Duration(seconds: 4),
   }) async {
-    printOnFailure('Test PlayerState: $playerState');
+    printWithTimeOnFailure('Test PlayerState: $playerState');
     final st = StackTrace.current.toString();
     await waitFor(
       () async {

--- a/packages/audioplayers/example/integration_test/tabs/source_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/source_tab.dart
@@ -10,7 +10,7 @@ Future<void> testSourcesTab(
   AppSourceTestData audioSourceTestData,
   PlatformFeatures features,
 ) async {
-  printOnFailure('Test Sources Tab');
+  printWithTimeOnFailure('Test Sources Tab');
   await tester.tap(find.byKey(const Key('sourcesTab')));
   await tester.pumpAndSettle();
 
@@ -19,7 +19,7 @@ Future<void> testSourcesTab(
 
 extension ControlsWidgetTester on WidgetTester {
   Future<void> testSource(String sourceKey) async {
-    printOnFailure('Test setting source: $sourceKey');
+    printWithTimeOnFailure('Test setting source: $sourceKey');
     final st = StackTrace.current.toString();
     final sourceWidgetKey = Key('setSource-$sourceKey');
     await scrollToAndTap(sourceWidgetKey);

--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -77,8 +77,8 @@ Future<void> testStreamsTab(
   if (features.hasPlayerStateEvent) {
     if (!audioSourceTestData.isLiveStream) {
       if (audioSourceTestData.duration < const Duration(seconds: 2)) {
-        await tester.testPlayerState(PlayerState.completed);
-        await tester.testOnPlayerState(PlayerState.completed);
+        await tester.testPlayerState(PlayerState.completed, timeout: timeout);
+        await tester.testOnPlayerState(PlayerState.completed, timeout: timeout);
       } else if (audioSourceTestData.duration > const Duration(seconds: 5)) {
         await tester.scrollToAndTap(const Key('pause_button'));
         await tester.pumpAndSettle();

--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -14,7 +14,7 @@ Future<void> testStreamsTab(
   AppSourceTestData audioSourceTestData,
   PlatformFeatures features,
 ) async {
-  printOnFailure('Test Streams Tab');
+  printWithTimeOnFailure('Test Streams Tab');
   await tester.tap(find.byKey(const Key('streamsTab')));
   await tester.pumpAndSettle();
 
@@ -140,7 +140,7 @@ extension StreamWidgetTester on WidgetTester {
     Duration duration, {
     Duration timeout = const Duration(seconds: 10),
   }) async {
-    printOnFailure('Test OnDuration: $duration');
+    printWithTimeOnFailure('Test OnDuration: $duration');
     final st = StackTrace.current.toString();
     await waitFor(
       () async => expectWidgetHasDuration(
@@ -157,7 +157,7 @@ extension StreamWidgetTester on WidgetTester {
     Matcher Function(Duration) matcher = equals,
     Duration timeout = const Duration(seconds: 10),
   }) async {
-    printOnFailure('Test OnPosition: $position');
+    printWithTimeOnFailure('Test OnPosition: $position');
     final st = StackTrace.current.toString();
     await waitFor(
       () async => expectWidgetHasDuration(
@@ -174,7 +174,7 @@ extension StreamWidgetTester on WidgetTester {
     PlayerState playerState, {
     Duration timeout = const Duration(seconds: 10),
   }) async {
-    printOnFailure('Test OnState: $playerState');
+    printWithTimeOnFailure('Test OnState: $playerState');
     final st = StackTrace.current.toString();
     await waitFor(
       () async => expectWidgetHasText(

--- a/packages/audioplayers/example/integration_test/test_utils.dart
+++ b/packages/audioplayers/example/integration_test/test_utils.dart
@@ -67,9 +67,9 @@ extension WidgetTesterUtils on WidgetTester {
     var lastFailureMsg = 'same as first failure';
     void setFailureMessage(String message) {
       if (firstFailureMsg.isEmpty) {
-        firstFailureMsg = message;
+        firstFailureMsg = '${DateTime.now()}:\n $message';
       } else {
-        lastFailureMsg = message;
+        lastFailureMsg = '${DateTime.now()}:\n $message';
       }
     }
 
@@ -215,4 +215,8 @@ void expectToggleHasSelected(
   } else {
     throw 'Widget with key $key is not a Widget of type "Tgl"';
   }
+}
+
+void printWithTimeOnFailure(String message) {
+  printOnFailure('${DateTime.now()}: $message');
 }


### PR DESCRIPTION
# Description

The CI sometimes fails, but it is hard to determine, what actually causes the long processing. So let's print some time stamps.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

Before:
```
```

After:
```
```

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
