### PR TITLE
fix(web): make start and resume async

### DIFF
--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -53,7 +53,7 @@ class AudioplayersPlugin extends AudioplayersPlatform with StreamsInterface {
 
   @override
   Future<void> resume(String playerId) async {
-    getOrCreatePlayer(playerId).resume();
+    await getOrCreatePlayer(playerId).resume();
   }
 
   @override

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -127,7 +127,7 @@ class WrappedPlayer {
     playerPlaySubscription = null;
   }
 
-  void start(double position) {
+  Future<void> start(double position) async {
     isPlaying = true;
     if (currentUrl == null) {
       return; // nothing to play yet
@@ -135,12 +135,12 @@ class WrappedPlayer {
     if (player == null) {
       recreateNode();
     }
-    player?.play();
+    await player?.play();
     player?.currentTime = position;
   }
 
-  void resume() {
-    start(pausedAt ?? 0);
+  Future<void> resume() async {
+    await start(pausedAt ?? 0);
   }
 
   void pause() {


### PR DESCRIPTION
# Description

If playing an invalid file (e.g. an empty file), the error is not propagated back to the library, as the error is thrown when starting the `play` / `resume` operation.
This ensures that the future of web js `play` is awaited.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality. Tests follow in #1352 
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

Before:
```
```

After:
```
```

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
