### PR TITLE
feat(web): make setUrl async, make properties of `WrappedPlayer` private

### DIFF
--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -93,7 +93,7 @@ class AudioplayersPlugin extends AudioplayersPlatform with StreamsInterface {
     String url, {
     bool? isLocal,
   }) async {
-    getOrCreatePlayer(playerId).setUrl(url);
+    await getOrCreatePlayer(playerId).setUrl(url);
   }
 
   @override


### PR DESCRIPTION
# Description

- make web `setUrl` async
- make properties of web `WrappedPlayer` private

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1436 