### PR TITLE
feat: replace `Platform.isX` with `defaultTargetPlatform`

### DIFF
--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 
 /// Specify supported features for a platform.
@@ -127,15 +125,15 @@ class PlatformFeatures {
   factory PlatformFeatures.instance() {
     return kIsWeb
         ? webPlatformFeatures
-        : Platform.isAndroid
+        : defaultTargetPlatform == TargetPlatform.android
             ? androidPlatformFeatures
-            : Platform.isIOS
+            : defaultTargetPlatform == TargetPlatform.iOS
                 ? iosPlatformFeatures
-                : Platform.isMacOS
+                : defaultTargetPlatform == TargetPlatform.macOS
                     ? macPlatformFeatures
-                    : Platform.isLinux
+                    : defaultTargetPlatform == TargetPlatform.linux
                         ? linuxPlatformFeatures
-                        : Platform.isWindows
+                        : defaultTargetPlatform == TargetPlatform.windows
                             ? windowsPlatformFeatures
                             : const PlatformFeatures();
   }

--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -101,7 +99,8 @@ Future<void> testStreamsTab(
 
   // Display duration & position after completion / stop
   // FIXME(Gustl22): Linux does not support duration after completion event
-  if (features.hasDurationEvent && (kIsWeb || !Platform.isLinux)) {
+  if (features.hasDurationEvent &&
+      (kIsWeb || defaultTargetPlatform != TargetPlatform.linux)) {
     await tester.testDuration(audioSourceTestData.duration);
     if (!audioSourceTestData.isLiveStream) {
       await tester.testOnDuration(

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/foundation.dart';
 
 /// An Audio Context is a set of secondary, platform-specific aspects of audio
@@ -26,12 +24,13 @@ class AudioContext {
   }
 
   Map<String, dynamic> toJson() {
-    // we need to check web first because `Platform.isX` fails on web
+    // we need to check web first because `defaultTargetPlatform` is not
+    // available for web.
     if (kIsWeb) {
       return <String, dynamic>{};
-    } else if (Platform.isAndroid) {
+    } else if (defaultTargetPlatform == TargetPlatform.android) {
       return android.toJson();
-    } else if (Platform.isIOS) {
+    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       return iOS.toJson();
     } else {
       return <String, dynamic>{};

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -1,6 +1,5 @@
-import 'dart:io' show Platform;
-
 import 'package:audioplayers_platform_interface/src/api/audio_context.dart';
+import 'package:flutter/foundation.dart';
 
 /// This class contains flags to control several secondary, platform-specific
 /// aspects of audio playback, like how this audio interact with other audios,
@@ -113,7 +112,7 @@ class AudioContextConfig {
   }
 
   AudioContextIOS buildIOS() {
-    if (Platform.isIOS) {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
       validateIOS();
     }
     return AudioContextIOS(


### PR DESCRIPTION
# Description

[Flutter recommends](https://api.flutter.dev/flutter/foundation/defaultTargetPlatform.html) using `defaultTargetPlatform` instead of `Platform.isX`, where possible. This also enables testing platform specific dart code in unit tests (but without native code), which is way more convenient and faster.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
