### PR TITLE
feat(windows): show nuget download info explicitely in verbose mode

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -4,9 +4,12 @@ This tutorial should help you get started with the audioplayers library, coverin
 
 In order to install this package, add the [latest version](pub.dev/packages/audioplayers) of `audioplayers` to your `pubspec.yaml` file. This packages uses [the Federated Plugin](https://docs.flutter.dev/development/packages-and-plugins/developing-packages) guidelines to support multiple platforms, so it should just work on all supported platforms your app is built for without any extra configuration. You should not need to add the `audioplayers_*` packages directly.
 
-## Build Requirements
+## Setup Platforms
 
-Audioplayers for Linux (`audioplayers_linux`) is the only platform implementation which relies on additional dependencies. You need to fulfill [these requirements](packages/audioplayers_linux/requirements.md).
+For building and running for certain platforms you need pay attention to additional steps:
+
+* [Linux Setup](packages/audioplayers_linux/setup.md) (`audioplayers_linux`).
+* [Windows Setup](packages/audioplayers_windows/setup.md) (`audioplayers_windows`).
 
 ## AudioPlayer
 

--- a/packages/audioplayers_linux/setup.md
+++ b/packages/audioplayers_linux/setup.md
@@ -1,10 +1,10 @@
-# Requirements for Linux
+# Setup for Linux
 
 ## Debian
 
 ### Dev Dependencies
 
-[Flutter](https://docs.flutter.dev/get-started/install/linux#additional-linux-requirements) dependencies:
+[Flutter](https://docs.flutter.dev/get-started/install/linux#linux-setup) dependencies:
 
 ```bash
 sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev

--- a/packages/audioplayers_windows/setup.md
+++ b/packages/audioplayers_windows/setup.md
@@ -1,0 +1,5 @@
+# Setup for Windows
+
+Please follow the Flutter guide to [set up Flutter on Windows](https://docs.flutter.dev/get-started/install/windows#windows-setup).
+
+Optionally you can add the individual component `NuGet package manager` inside **Visual Studio** or **Visual Studio Build Tools**, otherwise it will be downloaded while building.

--- a/packages/audioplayers_windows/windows/CMakeLists.txt
+++ b/packages/audioplayers_windows/windows/CMakeLists.txt
@@ -16,8 +16,12 @@ FetchContent_Declare(nuget
 
 find_program(NUGET nuget)
 if (NOT NUGET)
+    execute_process(
+        COMMAND ping dist.nuget.org -n 2 -w 1000
+        RESULT_VARIABLE NO_CONNECTION
+    )
     if(NO_CONNECTION GREATER 0)
-        message("Nuget.exe not found and not connected to the internet, trying use cached version.")
+        message("Nuget.exe not found and dist.nuget.org is not reachable, trying to use cached version.")
         set(FETCHCONTENT_FULLY_DISCONNECTED ON)
     else()
         message(STATUS "Nuget.exe not found, trying to download or use cached version.")

--- a/packages/audioplayers_windows/windows/CMakeLists.txt
+++ b/packages/audioplayers_windows/windows/CMakeLists.txt
@@ -9,14 +9,20 @@ include(FetchContent)
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 FetchContent_Declare(nuget
-  URL "https://dist.nuget.org/win-x86-commandline/v6.0.0/nuget.exe"
-  URL_HASH SHA256=04eb6c4fe4213907e2773e1be1bbbd730e9a655a3c9c58387ce8d4a714a5b9e1
+  URL "https://dist.nuget.org/win-x86-commandline/v6.5.0/nuget.exe"
+  URL_HASH SHA256=d5fce5185de92b7356ea9264b997a620e35c6f6c3c061e471e0dc3a84b3d74fd
   DOWNLOAD_NO_EXTRACT true
 )
 
 find_program(NUGET nuget)
 if (NOT NUGET)
-    message("Nuget.exe not found, trying to download or use cached version.")
+    if(NO_CONNECTION GREATER 0)
+        message("Nuget.exe not found and not connected to the internet, trying use cached version.")
+        set(FETCHCONTENT_FULLY_DISCONNECTED ON)
+    else()
+        message(STATUS "Nuget.exe not found, trying to download or use cached version.")
+        set(FETCHCONTENT_FULLY_DISCONNECTED OFF)
+    endif()
     FetchContent_MakeAvailable(nuget)
     set(NUGET ${nuget_SOURCE_DIR}/nuget.exe)
 endif()

--- a/packages/audioplayers_windows/windows/CMakeLists.txt
+++ b/packages/audioplayers_windows/windows/CMakeLists.txt
@@ -16,17 +16,7 @@ FetchContent_Declare(nuget
 
 find_program(NUGET nuget)
 if (NOT NUGET)
-    execute_process(
-        COMMAND ping dist.nuget.org -n 2 -w 1000
-        RESULT_VARIABLE NO_CONNECTION
-    )
-    if(NO_CONNECTION GREATER 0)
-        message("Nuget.exe not found and dist.nuget.org is not reachable, trying to use cached version.")
-        set(FETCHCONTENT_FULLY_DISCONNECTED ON)
-    else()
-        message(STATUS "Nuget.exe not found, trying to download or use cached version.")
-        set(FETCHCONTENT_FULLY_DISCONNECTED OFF)
-    endif()
+    message(STATUS "Nuget.exe not found, trying to download or use cached version.")
     FetchContent_MakeAvailable(nuget)
     set(NUGET ${nuget_SOURCE_DIR}/nuget.exe)
 endif()

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -74,8 +74,12 @@ flutter pub get
 1. If the problem still persists, and no existing (open or closed) issue on this repo, no stack overflow question or existing discord discussion solves you problem, then you can open an issue. But you must follow the issue template, and refer to the problem on the example app (or start with its code and make only the necessary modifications to trigger the issue), not on your own app that we don't have access (because since step 2 the error must be reproducible on the example app).
 1. Again, only open an issue if you reached step 3 and follow the issue template closely. Build issues that do not follow these steps will be closed without warning.
 
-### [Linux] Build Requirements
-In order to use the package `audioplayers_linux` you need to fulfill [these requirements](packages/audioplayers_linux/requirements.md).
+### Build Requirements
+
+Some platforms need additional requirements to be fulfilled:
+
+* [Linux](packages/audioplayers_linux/setup.md) (`audioplayers_linux`).
+* [Windows](packages/audioplayers_windows/setup.md) (`audioplayers_windows`).
 
 ## [iOS] Background Audio
 


### PR DESCRIPTION
# Description

The standard cmake message command prints to `stderr`. So it prints `Nuget.exe not found, trying to download or use cached version.`, when building an audioplayers app, which is confusing, as nothing went wrong. The `STATUS` keyword changes it to `stdout`, which can be accessed via the `flutter --verbose` command.
Also: 
- updated the `nuget` package to `v6.5.0`
- updated the docs on how to setup Windows and Linux. The paths could change again, once there are individual READMEs for each platform.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1319
#1114
Closes #1303