### PR TITLE
test: fix await closing event controller

### DIFF
--- a/packages/audioplayers/test/audioplayers_test.dart
+++ b/packages/audioplayers/test/audioplayers_test.dart
@@ -130,6 +130,9 @@ void main() {
       playerEvents.forEach((playerEvent) {
         platform.eventStreamController.add(playerEvent);
       });
+
+      // Await closing controller to avoid handling events after test finishes.
+      await platform.eventStreamController.close();
     });
   });
 }

--- a/packages/audioplayers/test/global_audioplayers_test.dart
+++ b/packages/audioplayers/test/global_audioplayers_test.dart
@@ -71,6 +71,9 @@ void main() {
       globalEvents.forEach((globalEvent) {
         globalPlatform.eventStreamController.add(globalEvent);
       });
+
+      // Await closing controller to avoid handling events after test finishes.
+      await globalPlatform.eventStreamController.close();
     });
   });
 }

--- a/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
@@ -139,7 +139,8 @@ void main() {
         );
       }
 
-      eventController.close();
+      // Await closing controller to avoid handling events after test finishes.
+      await eventController.close();
     });
   });
 }

--- a/packages/audioplayers_platform_interface/test/global_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/global_platform_test.dart
@@ -126,7 +126,8 @@ void main() {
         );
       }
 
-      eventController.close();
+      // Await closing controller to avoid handling events after test finishes.
+      await eventController.close();
     });
   });
 }


### PR DESCRIPTION
# Description

Sometimes the tests fail, because the events are emitted after the event tests are finished. This awaits the controller to prevent such behavior.

_I could not reproduce locally, but I'm quite sure this is the reason._

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

See https://github.com/bluefireteam/audioplayers/actions/runs/4606766296/jobs/8140467339