### PR TITLE
fix(android): Avoid calling onDuration on position event (closes #136)

### DIFF
--- a/packages/audioplayers/example/.metadata
+++ b/packages/audioplayers/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled.
 
 version:
-  revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
+  revision: 62bd79521d8d007524e351747471ba66696fc2d4
   channel: stable
 
 project_type: app
@@ -13,11 +13,26 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-      base_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
     - platform: android
-      create_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
-      base_revision: ffccd96b62ee8cec7740dab303538c5fc26ac543
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+    - platform: ios
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+    - platform: linux
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+    - platform: macos
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+    - platform: web
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+    - platform: windows
+      create_revision: 62bd79521d8d007524e351747471ba66696fc2d4
+      base_revision: 62bd79521d8d007524e351747471ba66696fc2d4
 
   # User provided section
 

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -290,9 +290,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                     continue
                 }
                 isAnyPlaying = true
-                val duration = player.getDuration()
                 val time = player.getCurrentPosition()
-                player.eventHandler.success("audio.onDuration", hashMapOf("value" to (duration ?: 0)))
                 player.eventHandler.success("audio.onCurrentPosition", hashMapOf("value" to (time ?: 0)))
             }
             if (isAnyPlaying) {


### PR DESCRIPTION
# Description

Unlike on other platforms, onDuration is constantly called on Android. This PR avoids calling onDuration on every position event.
OnDuration is still once called with the correct duration after having prepared the source.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #136
