### PR TITLE
docs: Update AudioContextConfig link to docs

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -197,7 +197,7 @@ To configure a player specific Audio Context (if desired), use:
 
 **Note:** As the iOS platform can not handle contexts for each player individually, for convenience this would also set the Audio Context globally.
 
-While each platform has its own set of configurations, they are somewhat related, and you can create them using a unified interface call [`AudioContextConfig`](https://pub.dev/documentation/audioplayers_platform_interface/latest/src_api_audio_context_config/src_api_audio_context_config-library.html).
+While each platform has its own set of configurations, they are somewhat related, and you can create them using a unified interface call [`AudioContextConfig`](https://pub.dev/documentation/audioplayers/latest/audioplayers/AudioContextConfig-class.html).
 It provides generic abstractions that convey intent, that are then converted to platform specific configurations.
 
 Note that if this process is not perfect, you can create your configuration from scratch by providing exact details for each platform via


### PR DESCRIPTION
# Description

The estimated link for the dart docs, didn't work out for the release, so changed it to https://pub.dev/documentation/audioplayers/latest/audioplayers/AudioContextConfig-class.html


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Related Issues

See #1442
