### PR TITLE
fix: dispose player implementation

### DIFF
--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -206,6 +206,17 @@ void main() {
     );
   });
 
+  group('Platform method channel', () {
+    testWidgets('#create and #dispose', (tester) async {
+      final platform = AudioplayersPlatformInterface.instance;
+
+      const playerId = 'somePlayerId';
+      await platform.create(playerId);
+      await tester.pumpAndSettle();
+      await platform.dispose(playerId);
+    });
+  });
+
   group('Logging', () {
     testWidgets('Emit platform log', (tester) async {
       final completer = Completer<String>();

--- a/packages/audioplayers/example/lib/main.dart
+++ b/packages/audioplayers/example/lib/main.dart
@@ -90,8 +90,7 @@ class _ExampleAppState extends State<ExampleApp> {
       case PopupAction.remove:
         setState(() {
           if (audioPlayers.isNotEmpty) {
-            selectedAudioPlayer.stop();
-            selectedAudioPlayer.release();
+            selectedAudioPlayer.dispose();
             audioPlayers.removeAt(selectedPlayerIdx);
           }
           // Adjust index to be in valid range

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -351,7 +351,7 @@ class AudioPlayer {
     await release();
 
     await _platform.dispose(playerId);
-    
+
     final futures = <Future>[
       if (!_playerStateController.isClosed) _playerStateController.close(),
       _onPlayerCompleteStreamSubscription.cancel(),

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -222,7 +222,7 @@ class AudioPlayer {
   /// The resources are going to be fetched or buffered again as soon as you
   /// call [resume] or change the source.
   Future<void> release() async {
-    await creatingCompleter.future;
+    await stop();
     await _platform.release(playerId);
     state = PlayerState.stopped;
     _source = null;
@@ -350,8 +350,9 @@ class AudioPlayer {
     // First stop and release all native resources.
     await release();
 
+    await _platform.dispose(playerId);
+    
     final futures = <Future>[
-      creatingCompleter.future,
       if (!_playerStateController.isClosed) _playerStateController.close(),
       _onPlayerCompleteStreamSubscription.cancel(),
       _onLogStreamSubscription.cancel(),
@@ -362,6 +363,5 @@ class AudioPlayer {
     _source = null;
 
     await Future.wait<dynamic>(futures);
-    await _platform.dispose(playerId);
   }
 }

--- a/packages/audioplayers/test/audioplayers_test.dart
+++ b/packages/audioplayers/test/audioplayers_test.dart
@@ -32,15 +32,17 @@ void main() {
       expect(player.source, null);
     });
 
-    test('#setSource', () async {
+    test('#setSource and #dispose', () async {
       await player.setSource(UrlSource('internet.com/file.mp3'));
       expect(platform.popLastCall().method, 'setSourceUrl');
       expect(player.source, isInstanceOf<UrlSource>());
       final urlSource = player.source as UrlSource?;
       expect(urlSource?.url, 'internet.com/file.mp3');
 
-      await player.release();
-      expect(platform.popLastCall().method, 'release');
+      await player.dispose();
+      expect(platform.popCall().method, 'stop');
+      expect(platform.popCall().method, 'release');
+      expect(platform.popLastCall().method, 'dispose');
       expect(player.source, null);
     });
 

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -119,11 +119,6 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
         val player = getPlayer(playerId)
         try {
             when (call.method) {
-                "dispose" -> {
-                    player.dispose()
-                    players.remove(playerId)
-                }
-
                 "setSourceUrl" -> {
                     val url = call.argument<String>("url") ?: error("url is required")
                     val isLocal = call.argument<Boolean>("isLocal") ?: false
@@ -152,10 +147,10 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                     player.volume = volume.toFloat()
                 }
 
-            "setBalance" -> {
-                val balance = call.argument<Double>("balance") ?: error("balance is required")
-                player.balance = balance.toFloat()
-            }
+                "setBalance" -> {
+                    val balance = call.argument<Double>("balance") ?: error("balance is required")
+                    player.balance = balance.toFloat()
+                }
 
                 "setPlaybackRate" -> {
                     val rate = call.argument<Double>("playbackRate") ?: error("playbackRate is required")
@@ -196,6 +191,11 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                     val code = call.argument<String>("code") ?: error("code is required")
                     val message = call.argument<String>("message") ?: error("message is required")
                     player.handleError(code, message, null)
+                }
+
+                "dispose" -> {
+                    player.dispose()
+                    players.remove(playerId)
                 }
 
                 else -> {

--- a/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
@@ -253,6 +253,9 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
                 return
             }
             player.eventHandler.onError(code: code, message: message, details: nil)
+        } else if method == "dispose" {
+            player.dispose()
+            players[playerId] = nil
         } else {
             result(FlutterMethodNotImplemented)
             return

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -217,7 +217,7 @@ static void audioplayers_linux_plugin_handle_method_call(
             result = 1;
         } else if (strcmp(method, "dispose") == 0) {
             player->Dispose();
-            audioPlayers.erase(playerId)
+            audioPlayers.erase(playerId);
             result = 1;
         } else {
             response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -215,6 +215,10 @@ static void audioplayers_linux_plugin_handle_method_call(
                 flMessage == nullptr ? "" : fl_value_get_string(flMessage);
             player->OnError(code, message, nullptr, nullptr);
             result = 1;
+        } else if (strcmp(method, "dispose") == 0) {
+            player->Dispose();
+            audioPlayers.erase(playerId)
+            result = 1;
         } else {
             response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
             fl_method_call_respond(method_call, response, nullptr);

--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -152,9 +152,8 @@ class WebAudioplayersPlatform extends AudioplayersPlatformInterface {
 
   @override
   Future<void> dispose(String playerId) async {
-    await Future.forEach<WrappedPlayer>(
-      players.values,
-      (player) => player.dispose(),
-    );
+    final player = getPlayer(playerId);
+    await player.dispose();
+    players.remove(playerId);
   }
 }

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -223,7 +223,7 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("dispose") == 0) {
         player->Dispose();
-        audioPlayers.erase(playerId)
+        audioPlayers.erase(playerId);
         result->Success(EncodableValue(1));
     } else {
         result->NotImplemented();

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -221,6 +221,10 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
         auto message = GetArgument<std::string>("message", args, std::string());
         player->OnError(code, message, nullptr);
         result->Success(EncodableValue(1));
+    } else if (method_call.method_name().compare("dispose") == 0) {
+        player->Dispose();
+        audioPlayers.erase(playerId)
+        result->Success(EncodableValue(1));
     } else {
         result->NotImplemented();
     }


### PR DESCRIPTION
# Description

The implementation to dispose a player on the native side was missing for many platforms.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

See https://github.com/bluefireteam/audioplayers/issues/1467#issuecomment-1503685651
