### PR TITLE
fix(web): Avoid stutter when starting playback

### DIFF
--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -159,8 +159,8 @@ class WrappedPlayer {
     if (player == null) {
       recreateNode();
     }
-    await player?.play();
     player?.currentTime = position;
+    await player?.play();
   }
 
   Future<void> resume() async {


### PR DESCRIPTION
# Description

Setting `currentTime` of `AudioElement` after calling `play` can cause a stutter, if the browser is able to start playback of the audio immediately and execution after `play` is delayed by other tasks in the event loop.

By setting `currentTime` before calling `play` this issue can be avoided.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

Before:
```
```

After:
```
```

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
