### PR TITLE
fix: rework dispose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter run integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter run integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   macos:
     runs-on: macos-13
@@ -190,8 +190,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter run -d macos integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter run -d macos integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d macos integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d macos integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
       - name: Run Android unit tests
         working-directory: ./packages/audioplayers/example/android
@@ -245,5 +245,5 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           ( cd server; dart run bin/server.dart ) &
-          flutter test -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter run integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter run integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
       - name: Run Android unit tests
         working-directory: ./packages/audioplayers/example/android

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   macos:
     runs-on: macos-13
@@ -190,8 +190,8 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test -d macos integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test -d macos integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d macos integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d macos integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,5 +245,5 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           ( cd server; dart run bin/server.dart ) &
-          flutter run -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter run -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true

--- a/getting_started.md
+++ b/getting_started.md
@@ -54,6 +54,22 @@ Or, if you want to set the url and start playing, using the `play` shortcut:
 
 After the URL is set, you can use the following methods to control the player:
 
+### resume
+
+Starts playback from current position (by default, from the start).
+
+```dart
+  await player.resume();
+```
+
+### seek
+
+Changes the current position (note: this does not affect the "playing" status).
+
+```dart
+  await player.seek(Duration(milliseconds: 1200));
+```
+
 ### pause
 
 Stops the playback but keeps the current position.
@@ -72,20 +88,20 @@ Stops the playback and also resets the current position.
 
 ### release
 
-Equivalent to calling `stop` and then disposing of any resources associated with this player.
+Equivalent to calling `stop` and then releasing of any resources associated with this player.
 
-This means that any streams will be disposed, memory might be de-allocated, etc.
+This means that memory might be de-allocated, etc.
 
 Note that the player is also in a ready-to-use state; if you call `resume` again any necessary resources will be re-fetch.
 
 Particularly on Android, the media player is quite resource-intensive, and this will let it go. Data will be buffered again when needed (if it's a remote file, it will be downloaded again.
 
-### resume
+### dispose
 
-Starts playback from current position (by default, from the start).
+Disposes the player. It is calling `release` and also closes all open streams. This player instance must not be used anymore!
 
 ```dart
-  await player.resume();
+  await player.dispose();
 ```
 
 ### play
@@ -98,14 +114,6 @@ Play is just a shortcut method that allows you to:
   * resume (start playing immediately)
 
 All in a single function call. For most simple use cases, it might be the only method you need.
-
-### seek
-
-Changes the current position (note: this does not affect the "playing" status).
-
-```dart
-  await player.seek(Duration(milliseconds: 1200));
-```
 
 ## Player Parameters
 

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -70,18 +70,15 @@ void main() {
       (WidgetTester tester) async {
         final players =
             List.generate(audioTestDataList.length, (_) => AudioPlayer());
-        print("Dispose Debug A");
 
         // Start all players simultaneously
         final iterator = List<int>.generate(audioTestDataList.length, (i) => i);
         await Future.wait<void>(
           iterator.map((i) => players[i].play(audioTestDataList[i].source)),
         );
-        print("Dispose Debug B");
         await tester.pumpAndSettle();
         // Sources take some time to get initialized
         await tester.pump(const Duration(seconds: 8));
-        print("Dispose Debug C");
         for (var i = 0; i < audioTestDataList.length; i++) {
           final td = audioTestDataList[i];
           if (td.isLiveStream || td.duration > const Duration(seconds: 10)) {
@@ -92,9 +89,7 @@ void main() {
           }
           await players[i].stop();
         }
-        print("Dispose Debug D");
         await Future.wait(players.map((p) => p.dispose()));
-        print("Dispose Debug E");
       },
       // FIXME: Causes media error on Android (see #1333, #1353)
       // Unexpected platform error: MediaPlayer error with
@@ -104,10 +99,8 @@ void main() {
 
     testWidgets('play multiple sources consecutively',
         (WidgetTester tester) async {
-          print("Dispose Debug F");
       final player = AudioPlayer();
 
-          print("Dispose Debug G");
       for (var i = 0; i < audioTestDataList.length; i++) {
         final td = audioTestDataList[i];
         await player.play(td.source);
@@ -120,10 +113,8 @@ void main() {
           printWithTimeOnFailure('Test position: $td');
           expect(position, greaterThan(Duration.zero));
         }
-        print("Dispose Debug H");
         await player.stop();
       }
-          print("Dispose Debug I");
       await player.dispose();
     });
   });

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -70,15 +70,18 @@ void main() {
       (WidgetTester tester) async {
         final players =
             List.generate(audioTestDataList.length, (_) => AudioPlayer());
+        print("Dispose Debug A");
 
         // Start all players simultaneously
         final iterator = List<int>.generate(audioTestDataList.length, (i) => i);
         await Future.wait<void>(
           iterator.map((i) => players[i].play(audioTestDataList[i].source)),
         );
+        print("Dispose Debug B");
         await tester.pumpAndSettle();
         // Sources take some time to get initialized
         await tester.pump(const Duration(seconds: 8));
+        print("Dispose Debug C");
         for (var i = 0; i < audioTestDataList.length; i++) {
           final td = audioTestDataList[i];
           if (td.isLiveStream || td.duration > const Duration(seconds: 10)) {
@@ -89,7 +92,9 @@ void main() {
           }
           await players[i].stop();
         }
+        print("Dispose Debug D");
         await Future.wait(players.map((p) => p.dispose()));
+        print("Dispose Debug E");
       },
       // FIXME: Causes media error on Android (see #1333, #1353)
       // Unexpected platform error: MediaPlayer error with
@@ -99,8 +104,10 @@ void main() {
 
     testWidgets('play multiple sources consecutively',
         (WidgetTester tester) async {
+          print("Dispose Debug F");
       final player = AudioPlayer();
 
+          print("Dispose Debug G");
       for (var i = 0; i < audioTestDataList.length; i++) {
         final td = audioTestDataList[i];
         await player.play(td.source);
@@ -113,8 +120,10 @@ void main() {
           printWithTimeOnFailure('Test position: $td');
           expect(position, greaterThan(Duration.zero));
         }
+        print("Dispose Debug H");
         await player.stop();
       }
+          print("Dispose Debug I");
       await player.dispose();
     });
   });

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -214,6 +214,9 @@ void main() {
       await platform.create(playerId);
       await tester.pumpAndSettle();
       await platform.dispose(playerId);
+      
+      // Call method after player has been released
+      await platform.stop(playerId);
     });
   });
 

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -364,6 +364,7 @@ void main() {
       expect(platformException.code, 'SomeGlobalErrorCode');
       expect(platformException.message, 'SomeGlobalErrorMessage');
       await eventStreamSub.cancel();
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -350,7 +350,7 @@ void main() {
     testWidgets('Emit global platform error', (tester) async {
       final errorCompleter = Completer<Object>();
       final global = GlobalAudioplayersPlatformInterface.instance;
-      final eventStreamSub = global
+      global
           .getGlobalEventStream()
           .listen((_) {}, onError: errorCompleter.complete);
 
@@ -363,8 +363,9 @@ void main() {
       final platformException = exception as PlatformException;
       expect(platformException.code, 'SomeGlobalErrorCode');
       expect(platformException.message, 'SomeGlobalErrorMessage');
-      await eventStreamSub.cancel();
-      await tester.pumpAndSettle();
+      // FIXME: cancelling the global event stream leads to
+      // MissingPluginException on Android
+      // await eventStreamSub.cancel();
     });
   });
 }

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -214,9 +214,17 @@ void main() {
       await platform.create(playerId);
       await tester.pumpAndSettle();
       await platform.dispose(playerId);
-      
-      // Call method after player has been released
-      await platform.stop(playerId);
+
+      try {
+        // Call method after player has been released should throw a PlatformException
+        await platform.stop(playerId);
+        fail('PlatformException not thrown');
+      } on PlatformException catch (e) {
+        expect(
+          e.message,
+          'Player has not yet been created or has already been disposed.',
+        );
+      }
     });
   });
 

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -221,7 +221,8 @@ void main() {
       await platform.dispose(playerId);
 
       try {
-        // Call method after player has been released should throw a PlatformException
+        // Call method after player has been released should throw a
+        // PlatformException
         await platform.stop(playerId);
         fail('PlatformException not thrown');
       } on PlatformException catch (e) {

--- a/packages/audioplayers/lib/src/audio_pool.dart
+++ b/packages/audioplayers/lib/src/audio_pool.dart
@@ -123,4 +123,8 @@ class AudioPool {
     await player.setReleaseMode(ReleaseMode.stop);
     return player;
   }
+
+  /// Disposes the audio pool. Then it cannot be used anymore.
+  Future<void> dispose() =>
+      Future.wait(availablePlayers.map((e) => e.dispose()));
 }

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -35,7 +35,7 @@ class AudioPlayer {
   Source? get source => _source;
 
   set state(PlayerState state) {
-    if(_playerState == PlayerState.disposed) {
+    if (_playerState == PlayerState.disposed) {
       throw Exception('AudioPlayer has been disposed');
     }
     if (!_playerStateController.isClosed) {
@@ -352,7 +352,7 @@ class AudioPlayer {
   Future<void> dispose() async {
     // First stop and release all native resources.
     await release();
-    
+
     state = PlayerState.disposed;
 
     final futures = <Future>[

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -35,6 +35,9 @@ class AudioPlayer {
   Source? get source => _source;
 
   set state(PlayerState state) {
+    if(_playerState == PlayerState.disposed) {
+      throw Exception('AudioPlayer has been disposed');
+    }
     if (!_playerStateController.isClosed) {
       _playerStateController.add(state);
     }
@@ -349,6 +352,8 @@ class AudioPlayer {
   Future<void> dispose() async {
     // First stop and release all native resources.
     await release();
+    
+    state = PlayerState.disposed;
 
     await _platform.dispose(playerId);
 

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -355,8 +355,6 @@ class AudioPlayer {
     
     state = PlayerState.disposed;
 
-    await _platform.dispose(playerId);
-
     final futures = <Future>[
       if (!_playerStateController.isClosed) _playerStateController.close(),
       _onPlayerCompleteStreamSubscription.cancel(),
@@ -368,5 +366,8 @@ class AudioPlayer {
     _source = null;
 
     await Future.wait<dynamic>(futures);
+
+    // Needs to be called after cancelling event stream subscription:
+    await _platform.dispose(playerId);
   }
 }

--- a/packages/audioplayers/test/audioplayers_test.dart
+++ b/packages/audioplayers/test/audioplayers_test.dart
@@ -129,8 +129,8 @@ void main() {
         emitsInOrder(audioEvents),
       );
 
-      audioEvents.forEach(platform.eventStreamController.add);
-      await platform.eventStreamController.close();
+      audioEvents.forEach(platform.eventStreamControllers['p1']!.add);
+      await platform.eventStreamControllers['p1']!.close();
     });
   });
 }

--- a/packages/audioplayers/test/fake_audioplayers_platform.dart
+++ b/packages/audioplayers/test/fake_audioplayers_platform.dart
@@ -15,8 +15,7 @@ class FakeCall {
 class FakeAudioplayersPlatform extends AudioplayersPlatformInterface {
   List<FakeCall> calls = [];
 
-  StreamController<AudioEvent> eventStreamController =
-      StreamController<AudioEvent>.broadcast();
+  Map<String, StreamController<AudioEvent>> eventStreamControllers = {};
 
   void clear() {
     calls.clear();
@@ -34,12 +33,13 @@ class FakeAudioplayersPlatform extends AudioplayersPlatformInterface {
   @override
   Future<void> create(String playerId) async {
     calls.add(FakeCall(id: playerId, method: 'create'));
+    eventStreamControllers[playerId] = StreamController<AudioEvent>.broadcast();
   }
 
   @override
   Future<void> dispose(String playerId) async {
     calls.add(FakeCall(id: playerId, method: 'dispose'));
-    eventStreamController.close();
+    eventStreamControllers[playerId]?.close();
   }
 
   @override
@@ -147,6 +147,6 @@ class FakeAudioplayersPlatform extends AudioplayersPlatformInterface {
   @override
   Stream<AudioEvent> getEventStream(String playerId) {
     calls.add(FakeCall(id: playerId, method: 'getEventStream'));
-    return eventStreamController.stream;
+    return eventStreamControllers[playerId]!.stream;
   }
 }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -210,7 +210,7 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
     }
 
     private fun getPlayer(playerId: String): WrappedPlayer {
-        return players[playerId] ?: error("Player with id $playerId was not created!")
+        return players[playerId] ?: error("Player has not yet been created or has already been disposed.")
     }
 
     fun getApplicationContext(): Context {

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -365,7 +365,9 @@ class EventHandler(private val eventChannel: EventChannel) : EventChannel.Stream
     }
 
     fun dispose() {
-        eventSink?.endOfStream()
-        onCancel(null)
+        eventSink?.let {
+            it.endOfStream()
+            onCancel(null)
+        }
     }
 }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -353,6 +353,6 @@ class WrappedPlayer internal constructor(
 
     fun dispose() {
         release()
-        eventHandler.endOfStream()
+        eventHandler.dispose()
     }
 }

--- a/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
@@ -162,7 +162,10 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
             }
             return
         } else if method == "release" {
-            player.release()
+            player.release() {
+                result(1)
+            }
+            return
         } else if method == "seek" {
             guard let position = args["position"] as? Int else {
                 result(FlutterError(code: "DarwinAudioError", message: "Null position received on seek", details: nil))
@@ -257,8 +260,11 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
             }
             player.eventHandler.onError(code: code, message: message, details: nil)
         } else if method == "dispose" {
-            player.dispose()
-            players[playerId] = nil
+            player.dispose() {
+                self.players[playerId] = nil
+                result(1)
+            }
+            return
         } else {
             result(FlutterMethodNotImplemented)
             return

--- a/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
@@ -147,7 +147,10 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let player = self.getPlayer(playerId: playerId)
+        guard let player = self.getPlayer(playerId: playerId) else {
+            result(FlutterError(code: "DarwinAudioError", message: "Player has not yet been created or has already been disposed.", details: nil))
+            return
+        }
 
         if method == "pause" {
             player.pause()
@@ -279,8 +282,8 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
         players[playerId] = newPlayer
     }
 
-    func getPlayer(playerId: String) -> WrappedMediaPlayer {
-        return players[playerId]!
+    func getPlayer(playerId: String) -> WrappedMediaPlayer? {
+        return players[playerId]
     }
 
     func controlAudioSession() {

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -195,7 +195,7 @@ class WrappedMediaPlayer {
                 let interval = toCMTime(millis: 0.2)
                 let timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: nil) {
                     [weak self] time in
-                    self!.onTimeInterval(time: time)
+                    self?.onTimeInterval(time: time)
                 }
                 self.observers.append(TimeObserver(player: player, observer: timeObserver))
             }
@@ -206,7 +206,7 @@ class WrappedMediaPlayer {
                 queue: nil
             ) {
                 [weak self] (notification) in
-                self!.onSoundComplete()
+                self?.onSoundComplete()
             }
             self.observers.append(TimeObserver(player: player, observer: anObserver))
             

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -399,17 +399,25 @@ void AudioPlayer::Dispose() {
     
     g_source_remove(_refreshId);
 
-    if(bus) gst_object_unref(GST_OBJECT(bus));
-    if(source) gst_object_unref(GST_OBJECT(source));
+    if(bus) {
+        gst_bus_remove_watch(bus);
+        gst_object_unref(GST_OBJECT(bus));
+        bus = nullptr;
+    }
+
+    if(source) {
+        gst_object_unref(GST_OBJECT(source));
+        source = nullptr;
+    }
 
     if(panorama) {
         gst_element_set_state(audiobin, GST_STATE_NULL);
-        
+
         gst_element_remove_pad(audiobin, panoramaSinkPad);
         gst_bin_remove(GST_BIN(audiobin), audiosink);
         gst_bin_remove(GST_BIN(audiobin), panorama);
 
-        gst_object_unref(GST_OBJECT(audiobin));
+        // audiobin gets unreferenced (2x) via playbin
         panorama = nullptr;
     }
 

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -424,10 +424,6 @@ void AudioPlayer::Dispose() {
         // audiobin gets unreferenced (2x) via playbin
         panorama = nullptr;
     }
-
-    // FIXME(gustl22): find the reaseon for:
-    // GStreamer-CRITICAL: gst_element_set_state: assertion 'GST_IS_ELEMENT (element)' failed
-    // GStreamer-CRITICAL: gst_object_unref: assertion '((GObject *) object)->ref_count > 0' failed
     
     GstState playbinState;
     gst_element_get_state(playbin, &playbinState, NULL, GST_CLOCK_TIME_NONE);

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -6,6 +6,9 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *methodChannel,
                          FlEventChannel *eventChannel)
     : _playerId(playerId),
       _eventChannel(eventChannel) {
+    // Init GStreamer
+    gst_init(NULL, NULL);
+
     playbin = gst_element_factory_make("playbin", NULL);
     if (!playbin) {
         throw "Not all elements could be created.";

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -6,7 +6,8 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *methodChannel,
                          FlEventChannel *eventChannel)
     : _playerId(playerId),
       _eventChannel(eventChannel) {
-    // Init GStreamer
+    // GStreamer lib only needs to be initialized once, but doing it while registering the plugin can be problematic as
+    // it likely needs a GUI to be present. Calling it multiple times is fine.
     gst_init(NULL, NULL);
 
     playbin = gst_element_factory_make("playbin", NULL);

--- a/packages/audioplayers_linux/linux/audio_player.h
+++ b/packages/audioplayers_linux/linux/audio_player.h
@@ -72,6 +72,7 @@ class AudioPlayer {
     bool _isLooping = false;
     bool _isSeekCompleted = true;
     double _playbackRate = 1.0;
+    guint _refreshId;
 
     std::string _url{};
     std::string _playerId;

--- a/packages/audioplayers_linux/linux/audio_player.h
+++ b/packages/audioplayers_linux/linux/audio_player.h
@@ -59,10 +59,13 @@ class AudioPlayer {
 
    private:
     // Gst members
-    GstElement *playbin;
-    GstElement *source;
-    GstElement *panorama;
-    GstBus *bus;
+    GstElement *playbin = nullptr;
+    GstElement *source = nullptr;
+    GstElement *panorama = nullptr;
+    GstElement *audiobin = nullptr;
+    GstElement *audiosink = nullptr;
+    GstPad *panoramaSinkPad = nullptr;
+    GstBus *bus = nullptr;
 
     bool _isInitialized = false;
     bool _isPlaying = false;
@@ -72,7 +75,6 @@ class AudioPlayer {
 
     std::string _url{};
     std::string _playerId;
-    FlMethodChannel *_methodChannel;
     FlEventChannel *_eventChannel;
 
     static void SourceSetup(GstElement *playbin, GstElement *source,

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -251,7 +251,6 @@ static void audioplayers_linux_plugin_handle_method_call(
 }
 
 static void audioplayers_linux_plugin_dispose(GObject *object) {
-    g_print("Global dispose");
     for (const auto& entry : audioPlayers) {
         entry.second->Dispose();
     }

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -266,9 +266,7 @@ static void audioplayers_linux_plugin_class_init(
     G_OBJECT_CLASS(klass)->dispose = audioplayers_linux_plugin_dispose;
 }
 
-static void audioplayers_linux_plugin_init(AudioplayersLinuxPlugin *self) {
-    gst_init(NULL, NULL);
-}
+static void audioplayers_linux_plugin_init(AudioplayersLinuxPlugin *self) {}
 
 static void method_call_cb(FlMethodChannel *methods, FlMethodCall *method_call,
                            gpointer user_data) {
@@ -287,6 +285,9 @@ void audioplayers_linux_plugin_register_with_registrar(
     FlPluginRegistrar *registrar) {
     AudioplayersLinuxPlugin *plugin = AUDIOPLAYERS_LINUX_PLUGIN(
         g_object_new(audioplayers_linux_plugin_get_type(), nullptr));
+
+    // Init GStreamer
+    gst_init(NULL, NULL);
 
     binaryMessenger = fl_plugin_registrar_get_messenger(registrar);
 

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -227,8 +227,7 @@ static void audioplayers_linux_plugin_handle_method_call(
             result = 1;
         } else if (strcmp(method, "dispose") == 0) {
             player->Dispose();
-            auto searchPlayer = audioPlayers.find(playerId);
-            audioPlayers.erase(searchPlayer);
+            audioPlayers.erase(playerId);
             result = 1;
         } else {
             response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
@@ -244,8 +243,9 @@ static void audioplayers_linux_plugin_handle_method_call(
             "LinuxAudioError", error, nullptr));
         fl_method_call_respond(method_call, response, nullptr);
     } catch (...) {
+        std::exception_ptr p = std::current_exception();
         response = FL_METHOD_RESPONSE(fl_method_error_response_new(
-            "LinuxAudioError", "Unkown AudioPlayersLinux error", nullptr));
+            "LinuxAudioError", p ? p.__cxa_exception_type()->name() : "Unknown AudioPlayersLinux error", nullptr));
         fl_method_call_respond(method_call, response, nullptr);
     }
 }

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -48,6 +48,9 @@ static void audioplayers_linux_plugin_create_player(
 static AudioPlayer *audioplayers_linux_plugin_get_player(
     const std::string &playerId) {
     auto searchPlayer = audioPlayers.find(playerId);
+    if(searchPlayer == audioPlayers.end()) {
+        return nullptr;
+    }
     return searchPlayer->second.get();
 }
 
@@ -118,6 +121,13 @@ static void audioplayers_linux_plugin_handle_method_call(
     }
 
     auto player = audioplayers_linux_plugin_get_player(playerId);
+    if(!player) {
+        response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+                "LinuxAudioError", "Player has not yet been created or has already been disposed.",
+                nullptr));
+        fl_method_call_respond(method_call, response, nullptr);
+        return;
+    }
 
     try {
         if (strcmp(method, "pause") == 0) {

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -286,9 +286,6 @@ void audioplayers_linux_plugin_register_with_registrar(
     AudioplayersLinuxPlugin *plugin = AUDIOPLAYERS_LINUX_PLUGIN(
         g_object_new(audioplayers_linux_plugin_get_type(), nullptr));
 
-    // Init GStreamer
-    gst_init(NULL, NULL);
-
     binaryMessenger = fl_plugin_registrar_get_messenger(registrar);
 
     g_autoptr(FlStandardMethodCodec) methodCodec =

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -227,7 +227,8 @@ static void audioplayers_linux_plugin_handle_method_call(
             result = 1;
         } else if (strcmp(method, "dispose") == 0) {
             player->Dispose();
-            audioPlayers.erase(playerId);
+            auto searchPlayer = audioPlayers.find(playerId);
+            audioPlayers.erase(searchPlayer);
             result = 1;
         } else {
             response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
@@ -250,6 +251,14 @@ static void audioplayers_linux_plugin_handle_method_call(
 }
 
 static void audioplayers_linux_plugin_dispose(GObject *object) {
+    g_print("Global dispose");
+    for (const auto& entry : audioPlayers) {
+        entry.second->Dispose();
+    }
+    gst_deinit();
+    g_clear_object(&globalEvents);
+    g_clear_object(&globalMethods);
+    g_clear_object(&methods);
     G_OBJECT_CLASS(audioplayers_linux_plugin_parent_class)->dispose(object);
 }
 
@@ -258,7 +267,9 @@ static void audioplayers_linux_plugin_class_init(
     G_OBJECT_CLASS(klass)->dispose = audioplayers_linux_plugin_dispose;
 }
 
-static void audioplayers_linux_plugin_init(AudioplayersLinuxPlugin *self) {}
+static void audioplayers_linux_plugin_init(AudioplayersLinuxPlugin *self) {
+    gst_init(NULL, NULL);
+}
 
 static void method_call_cb(FlMethodChannel *methods, FlMethodCall *method_call,
                            gpointer user_data) {

--- a/packages/audioplayers_platform_interface/lib/src/api/player_state.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/player_state.dart
@@ -11,4 +11,7 @@ enum PlayerState {
 
   /// The audio successfully completed (reached the end).
   completed,
+  
+  /// The player has been disposed and should not be used anymore.
+  disposed,
 }

--- a/packages/audioplayers_platform_interface/lib/src/api/player_state.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/player_state.dart
@@ -11,7 +11,7 @@ enum PlayerState {
 
   /// The audio successfully completed (reached the end).
   completed,
-  
+
   /// The player has been disposed and should not be used anymore.
   disposed,
 }

--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -30,7 +30,8 @@ class WebAudioplayersPlatform extends AudioplayersPlatformInterface {
         ? players[playerId]!
         : throw PlatformException(
             code: 'WebAudioError',
-            message: 'Player with id $playerId was not created!',
+            message:
+                'Player has not yet been created or has already been disposed.',
           );
   }
 

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -147,6 +147,13 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
     }
 
     auto player = GetPlayer(playerId);
+    if(!player) {
+        result->Error(
+            "WindowsAudioError",
+            "Player has not yet been created or has already been disposed.",
+            nullptr);
+        return;
+    }
 
     if (method_call.method_name().compare("pause") == 0) {
         player->Pause();
@@ -248,6 +255,9 @@ void AudioplayersWindowsPlugin::CreatePlayer(std::string playerId) {
 
 AudioPlayer *AudioplayersWindowsPlugin::GetPlayer(std::string playerId) {
     auto searchPlayer = audioPlayers.find(playerId);
+    if(searchPlayer == audioPlayers.end()) {
+        return nullptr;
+    }
     return searchPlayer->second.get();
 }
 


### PR DESCRIPTION
# Description

- Add `PlayerState.disposed` (closes #1450)
- Add `AudioPool.dispose()` (closes #1478)
- Dispose players in tests
- Properly handle dispose on all platforms (closes #1475)
- Fix running method calls on non UI threads causes PlatformException (closes #1481)

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1450 
Closes #1478 
Closes #1475 
Closes #1481
