### PR TITLE
ci: fix macos integration tests, remove unnecessary actions

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -80,15 +80,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@main
 
@@ -97,7 +88,7 @@ jobs:
         run: flutter build apk --release
 
   ios:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     timeout-minutes: 30
     if: inputs.enable_ios
     steps:
@@ -110,7 +101,7 @@ jobs:
         run: flutter build ios --release --no-codesign
 
   macos:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     timeout-minutes: 30
     if: inputs.enable_macos
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
         run: "xcrun simctl list devices"
       - name: Start simulator
         run: |
-          UDID=$(xcrun simctl list devices | grep "iPhone 14" | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
+          UDID=$(xcrun simctl list devices | grep "iPhone" | sed -n 1p | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
           echo "Using simulator $UDID"
           xcrun simctl boot "${UDID:?No Simulator with this name iPhone found}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
         run: "xcrun simctl list devices"
       - name: Start simulator
         run: |
-          UDID=$(xcrun simctl list devices | grep "iPhone" | sed -n 1p | awk -F '\\)? \\(' '{ print $2 }')
+          UDID=$(xcrun simctl list devices | grep "iPhone 14" | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
           echo "Using simulator $UDID"
           xcrun simctl boot "${UDID:?No Simulator with this name iPhone found}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,5 +245,5 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           ( cd server; dart run bin/server.dart ) &
-          flutter test -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter run -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
            --dart-define USE_LOCAL_SERVER=true
 
   android:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     timeout-minutes: 90
     if: inputs.enable_android
     steps:
@@ -156,7 +156,7 @@ jobs:
         run: ./gradlew test
 
   ios:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     timeout-minutes: 60
     if: inputs.enable_ios
     steps:
@@ -181,16 +181,12 @@ jobs:
           flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   macos:
-    runs-on: macOS-latest
+    runs-on: macos-13
     timeout-minutes: 30
     if: inputs.enable_macos
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-        # TODO: Once GitHub CI supports metal we should bump the Flutter version to latest. (#1405)
-        with:
-          flutter-version: '3.3.10'
-          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: setup-cocoapods

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,20 +109,11 @@ jobs:
            --dart-define USE_LOCAL_SERVER=true
 
   android:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 90
     if: inputs.enable_android
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
 
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@main
@@ -156,7 +147,7 @@ jobs:
         run: ./gradlew test
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
     if: inputs.enable_ios
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
         run: ./gradlew test
 
   ios:
-    runs-on: macos-13
+    runs-on: macos-latest
     timeout-minutes: 60
     if: inputs.enable_ios
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,5 +245,5 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
           ( cd server; dart run bin/server.dart ) &
-          flutter run -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter run -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true


### PR DESCRIPTION
# Description

- Use Github Runner image `macos-13` for Integration tests (Closes #1405)
- Remove unnecessary actions

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues
