### PR TITLE
feat: Adapt position update interval of darwin, linux, web 

### DIFF
--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -127,7 +127,7 @@ extension StreamWidgetTester on WidgetTester {
   // Windows: ~250ms
   // Linux: ~250ms
   // Web: ~250ms
-  // Darwin: ?
+  // Darwin: ~200ms
 
   Future<void> stopStream() async {
     final st = StackTrace.current.toString();

--- a/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/tabs/stream_tab.dart
@@ -115,17 +115,19 @@ Future<void> testStreamsTab(
 }
 
 extension StreamWidgetTester on WidgetTester {
-  // Precision for duration & position:
-  // Android: two tenth of a second
+  // Precision for position & duration:
+  // Android: millisecond
   // Windows: millisecond
-  // Linux: second
-  // Web: second
+  // Linux: millisecond
+  // Web: millisecond
+  // Darwin: millisecond
 
-  // Update interval for duration & position:
-  // Android: two tenth of a second
+  // Update interval for position:
+  // Android: ~200ms
   // Windows: ~250ms
-  // Linux: second
-  // Web: second
+  // Linux: ~250ms
+  // Web: ~250ms
+  // Darwin: ?
 
   Future<void> stopStream() async {
     final st = StackTrace.current.toString();
@@ -144,7 +146,11 @@ extension StreamWidgetTester on WidgetTester {
     await waitFor(
       () async => expectWidgetHasDuration(
         const Key('onDurationText'),
-        matcher: (Duration? actual) => durationRangeMatcher(actual, duration),
+        matcher: (Duration? actual) => durationRangeMatcher(
+          actual,
+          duration,
+          deviation: const Duration(milliseconds: 500),
+        ),
       ),
       timeout: timeout,
       stackTrace: st,

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -198,7 +198,7 @@ class WrappedMediaPlayer {
                 self.url = url
                 
                 // stream player position
-                let interval = toCMTime(millis: 0.2)
+                let interval = toCMTime(millis: 200)
                 let timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: nil) {
                     [weak self] time in
                     self?.onTimeInterval(time: time)

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -20,7 +20,7 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *methodChannel,
     if (panorama) {
         audiobin = gst_bin_new(NULL);
         audiosink = gst_element_factory_make("autoaudiosink", NULL);
-        
+
         gst_bin_add_many(GST_BIN(audiobin), panorama, audiosink, NULL);
         gst_element_link(panorama, audiosink);
 
@@ -43,7 +43,7 @@ AudioPlayer::AudioPlayer(std::string playerId, FlMethodChannel *methodChannel,
     gst_bus_add_watch(bus, (GstBusFunc)AudioPlayer::OnBusMessage, this);
 
     // Refresh continuously to emit reoccurring events
-    _refreshId = g_timeout_add(1000, (GSourceFunc)AudioPlayer::OnRefresh, this);
+    _refreshId = g_timeout_add(250, (GSourceFunc)AudioPlayer::OnRefresh, this);
 }
 
 AudioPlayer::~AudioPlayer() {}

--- a/packages/audioplayers_web/lib/num_extension.dart
+++ b/packages/audioplayers_web/lib/num_extension.dart
@@ -1,6 +1,6 @@
 extension NumExtension on num {
   /// Converts [num] (expected in seconds) to the duration.
   Duration fromSecondsToDuration() => Duration(
-        seconds: (isNaN || isInfinite ? 0 : this).round(),
+        milliseconds: ((isNaN || isInfinite ? 0 : this) * 1000).round(),
       );
 }


### PR DESCRIPTION
# Description

- Linux: changed update interval from `1000ms` to `250ms`
- Web: `position` was rounded to `1s` as its handed over as float, now it's multiplied with `1000` to profit from millisecond precision, update interval is still dependent on browser implementation
- Darwin: changed update interval from `0.2ms` to `200ms`, which most probably was a mistake and caused much overhead

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues
