### PR TITLE
docs: Improve doc for 'AudioContextConfig.respectSilence' (#1490)

### DIFF
--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -43,9 +43,10 @@ class AudioContextConfig {
   /// thus is forbidden when [respectSilence] is set.
   final bool duckAudio;
 
-  /// Whether the "silent" mode of the device should be respect.
-  /// By default (false), if the device is on silent mode, the audio will not be
-  /// played.
+  /// Whether the "silent" mode of the device should be respected.
+  /// When `false` (the default), audio will be played even if the device is in
+  /// silent mode.
+  /// When `true` and the device is in silent mode, audio will not be played.
   ///
   /// On Android, this will mandate the `USAGE_NOTIFICATION_RINGTONE` usage
   /// type.

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -44,6 +44,7 @@ class AudioContextConfig {
   final bool duckAudio;
 
   /// Whether the "silent" mode of the device should be respected.
+  ///
   /// When `false` (the default), audio will be played even if the device is in
   /// silent mode.
   /// When `true` and the device is in silent mode, audio will not be played.

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -47,6 +47,7 @@ class AudioContextConfig {
   ///
   /// When `false` (the default), audio will be played even if the device is in
   /// silent mode.
+  ///
   /// When `true` and the device is in silent mode, audio will not be played.
   ///
   /// On Android, this will mandate the `USAGE_NOTIFICATION_RINGTONE` usage


### PR DESCRIPTION
# Description

Improves documentation for `AudioContextConfig.respectSilence`. It should now be easier to understand what it does.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality. (n/a)
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- ### Migration instructions

Before:
```
```

After:
```
```

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->
Fixes #1490.

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
