### PR TITLE
ci: Use fixed version of flutter-action

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Example app - Build Web app
@@ -79,8 +82,10 @@ jobs:
     if: inputs.enable_android
     steps:
       - uses: actions/checkout@v3
-
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Example App - Build Android APK
@@ -94,6 +99,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Example app - Build iOS
@@ -107,6 +115,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: setup-cocoapods
@@ -124,6 +135,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Example app - Build Windows app
@@ -137,6 +151,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Install Flutter requirements for Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - run: melos run format-check
@@ -80,6 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
       - uses: nanasess/setup-chromedriver@v1
 
@@ -114,8 +120,10 @@ jobs:
     if: inputs.enable_android
     steps:
       - uses: actions/checkout@v3
-
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: Download Android emulator image
@@ -153,6 +161,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: List all simulators
@@ -178,6 +189,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
       - name: setup-cocoapods
@@ -200,6 +214,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
       
       - name: Start audio server
@@ -227,6 +244,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.12'
+          channel: 'stable'
       - uses: bluefireteam/melos-action@main
       - name: Install Flutter requirements for Linux
         run: |


### PR DESCRIPTION
# Description

Like in [flame](https://github.com/flame-engine/flame/blob/19d1e72e4bb51550752b346525e51be67edc2019/.github/workflows/cicd.yml#L18) it is more practicable to use fixed version of `flutter-action` to avoid unexpected failures of the CI. 

Further when flutter is releasing a new version, one should upgrade the version of `flutter-action` and also add the required changes to pass the tests at the same time. 

This ensures that the tests in the main always stay consistent. It also makes the development faster and more independent of other packages such as `flame-lint`.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

https://github.com/flame-engine/flame/pull/2532

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
