### PR TITLE
fix(android): Add AGP 8 support with namespace property

### DIFF
--- a/packages/audioplayers_android/android/build.gradle
+++ b/packages/audioplayers_android/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1"
     }
@@ -30,6 +30,8 @@ apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
     compileSdk 33
+
+    namespace 'xyz.luan.audioplayers'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/audioplayers_android/android/build.gradle
+++ b/packages/audioplayers_android/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1"
     }
@@ -31,6 +31,7 @@ apply plugin: 'de.mannodermaus.android-junit5'
 android {
     compileSdk 33
 
+    // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty('namespace')) {
         namespace 'xyz.luan.audioplayers'
     }

--- a/packages/audioplayers_android/android/build.gradle
+++ b/packages/audioplayers_android/android/build.gradle
@@ -31,7 +31,9 @@ apply plugin: 'de.mannodermaus.android-junit5'
 android {
     compileSdk 33
 
-    namespace 'xyz.luan.audioplayers'
+    if (project.android.hasProperty('namespace')) {
+        namespace 'xyz.luan.audioplayers'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/audioplayers_android/android/src/main/AndroidManifest.xml
+++ b/packages/audioplayers_android/android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest
-        package="xyz.luan.audioplayers"/>
+<manifest package="xyz.luan.audioplayers"/>

--- a/packages/audioplayers_android/android/src/main/AndroidManifest.xml
+++ b/packages/audioplayers_android/android/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="xyz.luan.audioplayers"
-    android:versionCode="1"
-    android:versionName="0.1.0" />
+<manifest
+        package="xyz.luan.audioplayers"/>


### PR DESCRIPTION
# Description

Cherry-pick of #1503

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

### Optional Migration instructions

You can upgrade your Android project to use AGP 8. In your `android/build.gradle` :

```gradle
buildscript {
  // ...
  dependencies {
    classpath 'com.android.tools.build:gradle:8.0.1'
    // ...
  }
}
```

If doing so, also don't forget to add a namespace in the `android` section of `android/app/build.gradle` :

```gradle
android {
  // ...
  namespace 'your.namespace'
}
```

Then can also remove the `package` property in your `android/app/src/main/AndroidManifest.xml`

## Related Issues

#1503 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
