### PR TITLE
fix: IllegaleStateException on getCurrentPosition with more than 1 AudioPool on Android

### DIFF
--- a/packages/audioplayers/example/lib/tabs/sources.dart
+++ b/packages/audioplayers/example/lib/tabs/sources.dart
@@ -42,6 +42,16 @@ class _SourcesTabState extends State<SourcesTab>
     with AutomaticKeepAliveClientMixin<SourcesTab> {
   AudioPlayer get player => widget.player;
 
+  late AudioPool pool;
+  late AudioPool pool2;
+  late AudioPool pool3;
+
+  @override
+  void initState() {
+    _initPools();
+    super.initState();
+  }
+
   Future<void> _setSource(Source source) async {
     await player.setSource(source);
     toast(
@@ -99,6 +109,17 @@ class _SourcesTabState extends State<SourcesTab>
     if (path != null) {
       _setSource(DeviceFileSource(path));
     }
+  }
+
+  Future<void> _initPools() async {
+    pool = await AudioPool.createFromAsset(
+      path: wavAsset,
+      maxPlayers: 3,
+    );
+    pool2 = await AudioPool.createFromAsset(
+      path: mp3Asset,
+      maxPlayers: 3,
+    );
   }
 
   @override
@@ -183,6 +204,26 @@ class _SourcesTabState extends State<SourcesTab>
           source: AssetSource(invalidAsset),
           buttonColor: Colors.red,
         ),
+        ListTile(
+          title: const Text('AudioPool'),
+          subtitle: const Text('laser.wav pool'),
+          trailing: IconButton(
+            tooltip: 'Play',
+            onPressed: () => pool.start(),
+            icon: const Icon(Icons.play_arrow),
+            color: Theme.of(context).primaryColor,
+          ),
+        ),
+        ListTile(
+          title: const Text('AudioPool'),
+          subtitle: const Text('nasa_on_a_mission.mp3 pool'),
+          trailing: IconButton(
+            tooltip: 'Play',
+            onPressed: () => pool2.start(),
+            icon: const Icon(Icons.play_arrow),
+            color: Theme.of(context).primaryColor,
+          ),
+        )
       ],
     );
   }

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -21,7 +21,11 @@ flutter:
         default_package: audioplayers_windows
 
 dependencies:
-  audioplayers_android: ^3.0.2
+  audioplayers_android: 
+   git:
+      url: git@github.com:jgrandchavin/audioplayers
+      ref:  fix/illegale_state_exception_on_android
+      path: packages/audioplayers_android
   audioplayers_darwin: ^4.1.0
   audioplayers_linux: ^2.1.0
   audioplayers_platform_interface: ^5.0.1

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -80,7 +80,7 @@ class WrappedPlayer internal constructor(
     val isLooping: Boolean
         get() = releaseMode == ReleaseMode.LOOP
 
-    var playerMode: PlayerMode = MEDIA_PLAYER
+    var playerMode: PlayerMode = LOW_LATENCY
         set(value) {
             if (field != value) {
                 field = value


### PR DESCRIPTION
# Description

Initialized the player with `PlayerMode = MEDIA_PLAYER` will late throw error IllegaleStateException on `getCurrentPosition` when playing sound from more than 1 AudioPool. Put `PlayerMode = LOW_LATENCY` fix the issue

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- ### Migration instructions

Before:
```
```

After:
```
```

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
