### PR TITLE
feat(windows): Add millisecond level precision when seeking

### DIFF
--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
@@ -233,7 +233,7 @@ bool MediaEngineWrapper::GetLooping()
     return looping;
 }
 
-void MediaEngineWrapper::SeekTo(uint64_t timeStamp)
+void MediaEngineWrapper::SeekTo(double timeStamp)
 {
     RunSyncInMTA([&]()
     {
@@ -241,14 +241,14 @@ void MediaEngineWrapper::SeekTo(uint64_t timeStamp)
         if (m_mediaEngine == nullptr) {
             return;
         }
-        const double timestampInSeconds = ConvertHnsToSeconds(timeStamp);
+        const double timestampInSeconds = timeStamp / 1000.0;
         THROW_IF_FAILED(m_mediaEngine->SetCurrentTime(timestampInSeconds));
     });
 }
 
 uint64_t MediaEngineWrapper::GetMediaTime()
 {
-    uint64_t currentTimeInHns = 0;
+    uint64_t currentTime = 0;
     RunSyncInMTA([&]()
     {
         auto lock = m_lock.lock();
@@ -256,14 +256,14 @@ uint64_t MediaEngineWrapper::GetMediaTime()
             return;
         }
         double currentTimeInSeconds = m_mediaEngine->GetCurrentTime();
-        currentTimeInHns = ConvertSecondsToHns(currentTimeInSeconds);
+        currentTime = (uint64_t) (currentTimeInSeconds * 1000.0);
     });
-    return currentTimeInHns;
+    return currentTime;
 }
 
 uint64_t MediaEngineWrapper::GetDuration()
 {
-    uint64_t durationInHns = 0;
+    uint64_t duration = 0;
     RunSyncInMTA([&]()
     {
         auto lock = m_lock.lock();
@@ -271,9 +271,9 @@ uint64_t MediaEngineWrapper::GetDuration()
             return;
         }
         double durationInSeconds = m_mediaEngine->GetDuration();
-        durationInHns = ConvertSecondsToHns(durationInSeconds);
+        duration = (uint64_t) (durationInSeconds * 1000.0);
     });
-    return durationInHns;
+    return duration;
 }
 
 std::vector<std::tuple<uint64_t, uint64_t>> MediaEngineWrapper::GetBufferedRanges()

--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.h
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.h
@@ -49,7 +49,7 @@ class MediaEngineWrapper : public winrt::implements<MediaEngineWrapper, IUnknown
     void SetVolume(float volume);
     void SetBalance(double balance);
     void SetLooping(bool isLooping);
-    void SeekTo(uint64_t timeStamp);
+    void SeekTo(double timeStamp);
 
     // Query the current playback position
     uint64_t GetMediaTime();

--- a/packages/audioplayers_windows/windows/audio_player.cpp
+++ b/packages/audioplayers_windows/windows/audio_player.cpp
@@ -145,8 +145,7 @@ void AudioPlayer::OnTimeUpdate() {
                   flutter::EncodableValue("audio.onCurrentPosition")},
                  {flutter::EncodableValue("value"),
                   flutter::EncodableValue(
-                      (int64_t)m_mediaEngineWrapper->GetMediaTime() /
-                      10000)}})));
+                      (int64_t)m_mediaEngineWrapper->GetMediaTime())}})));
     }
 }
 
@@ -158,8 +157,7 @@ void AudioPlayer::OnDurationUpdate() {
                   flutter::EncodableValue("audio.onDuration")},
                  {flutter::EncodableValue("value"),
                   flutter::EncodableValue(
-                      (int64_t)m_mediaEngineWrapper->GetDuration() /
-                      10000)}})));
+                      (int64_t)m_mediaEngineWrapper->GetDuration())}})));
     }
 }
 
@@ -244,4 +242,4 @@ int64_t AudioPlayer::GetDuration() {
     return m_mediaEngineWrapper->GetDuration();
 }
 
-void AudioPlayer::SeekTo(int64_t seek) { m_mediaEngineWrapper->SeekTo(seek); }
+void AudioPlayer::SeekTo(double seek) { m_mediaEngineWrapper->SeekTo(seek); }

--- a/packages/audioplayers_windows/windows/audio_player.h
+++ b/packages/audioplayers_windows/windows/audio_player.h
@@ -73,7 +73,7 @@ class AudioPlayer {
 
     int64_t GetDuration();
 
-    void SeekTo(int64_t seek);
+    void SeekTo(double seek);
 
     void SetSourceUrl(std::string url);
 

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -14,6 +14,8 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <stdlib.h>
+#include <inttypes.h>
 
 #include "audio_player.h"
 
@@ -163,16 +165,15 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("stop") == 0) {
         player->Pause();
-        player->SeekTo(0);
+        player->SeekTo(0.0);
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("release") == 0) {
         player->Pause();
-        player->SeekTo(0);
+        player->SeekTo(0.0);
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("seek") == 0) {
-        auto position = GetArgument<int>("position", args,
-                                         (int)(player->GetPosition() / 10000));
-        player->SeekTo(static_cast<int64_t>(position * 10000.0));
+        auto position = GetArgument<double>("position", args, (double)(player->GetPosition()));
+        player->SeekTo(position);
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("setSourceUrl") == 0) {
         auto url = GetArgument<std::string>("url", args, std::string());
@@ -185,13 +186,13 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
         std::thread(&AudioPlayer::SetSourceUrl, player, url).detach();
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("getDuration") == 0) {
-        result->Success(EncodableValue(player->GetDuration() / 10000));
+        result->Success(EncodableValue(player->GetDuration()));
     } else if (method_call.method_name().compare("setVolume") == 0) {
         auto volume = GetArgument<double>("volume", args, 1.0);
         player->SetVolume(volume);
         result->Success(EncodableValue(1));
     } else if (method_call.method_name().compare("getCurrentPosition") == 0) {
-        result->Success(EncodableValue(player->GetPosition() / 10000));
+        result->Success(EncodableValue(player->GetPosition()));
     } else if (method_call.method_name().compare("setPlaybackRate") == 0) {
         auto playbackRate = GetArgument<double>("playbackRate", args, 1.0);
         player->SetPlaybackSpeed(playbackRate);


### PR DESCRIPTION
# Description

This pull request addresses the issue related to audio seeking precision in the Audioplayers plugin for Windows. The problem is currently limited to seconds instead of milliseconds. The proposed changes modify the code to support seeking with millisecond precision, allowing users to accurately seek to specific points within an audio file.

__Changes Made:__

__File:__ `MediaEngineWrapper.cpp`
Modified the `SeekTo` function:
Changed the parameter type from `uint64_t` to `double` for the `timeStamp` parameter.

Updated the calculation of` timestampInSeconds` to convert `timeStamp` from milliseconds to seconds (timeStamp / 1000.0).

Changed the call to `m_mediaEngine->SetCurrentTime` to use the updated `timestampInSeconds` value.

Modified the `GetMediaTime` function:
Removed the unnecessary assignment of `currentTime` in milliseconds.

Updated the calculation of `currentTimeInSeconds` to convert the current time from seconds to milliseconds `(currentTimeInSeconds * 1000.0)`.

Return only` currentTimeInHns` instead of both `currentTimeInHns` and `currentTime`.

Modified the `GetDuration1 function:
Updated the calculation of `durationInSeconds` to convert the duration from seconds to milliseconds `(durationInSeconds * 1000.0)`.
Return `duration`.

__File:__ `audio_player.cpp`
Modified the `OnTimeUpdate()` method:
Updated the `flutter::EncodableValue` for the `value` field to directly use `(int64_t)m_mediaEngineWrapper->GetMediaTime()` instead of dividing by 10000.

Modified the `OnDurationUpdate()` method:
Updated the `flutter::EncodableValue` for the `value` field to directly use `(int64_t)m_mediaEngineWrapper->GetDuration()` instead of dividing by 10000.

Modified the `SeekTo` function in the AudioPlayer class to accept a double parameter instead of `int64_t`.

__File:__ `audio_player.h`
Updated the function declaration of `SeekTo` in the AudioPlayer class to accept a `double` parameter instead of `int64_t`.

__File:__ `audioplayers_windows_plugin.cpp`
Modified the `seek` method to use `double` for the position argument and directly pass it to `player->SeekTo`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [X] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.


## Related Issues
https://github.com/bluefireteam/audioplayers/issues/1547