### PR TITLE
ci: Skip windows tests (#1573)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,7 +233,7 @@ jobs:
   windows:
     runs-on: windows-latest
     timeout-minutes: 30
-    if: inputs.enable_windows
+    if: false # FIXME(gustl22): Revert to "inputs.enable_windows" when virtual audio device can be installed (#1573)
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2


### PR DESCRIPTION
# Description

Windows tests currently cannot be executed as the certificate for the windows audio driver is expired.
Developers need to test locally in the mean time.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:`, `chore:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1573
https://github.com/duncanthrax/scream/issues/202

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
