### PR TITLE
ci(windows): Attempt to fix flakiness in setting windows time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,19 +267,19 @@ jobs:
         run: |
           Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
           Expand-Archive -Path Scream.zip -DestinationPath Scream
-          Set-Date (Get-Date "2023-07-04 12:00:00"); $currentDate = Get-Date; Write-Host "Current Date: $currentDate";
+          Set-Date (Get-Date "2023-07-04 12:00:00"); $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
           Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
           Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
-          w32tm /resync /force; $currentDate = Get-Date; Write-Host "Current Date: $currentDate";
-#      - name: Run Flutter integration tests
-#        shell: powershell
-#        working-directory: ./packages/audioplayers/example
-#        # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
-#        run: |
-#          Start-Process -NoNewWindow -WorkingDirectory "server" dart -ArgumentList "run", "bin/server.dart"
-#          flutter test -d windows integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
-#          flutter test -d windows integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-#          flutter test -d windows integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+          w32tm /resync /force; $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
+      - name: Run Flutter integration tests
+        shell: powershell
+        working-directory: ./packages/audioplayers/example
+        # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
+        run: |
+          Start-Process -NoNewWindow -WorkingDirectory "server" dart -ArgumentList "run", "bin/server.dart"
+          flutter test -d windows integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d windows integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test -d windows integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,7 @@ jobs:
       - name: Start audio server
         run: net start audiosrv
       - name: Install virtual audio device
+        timeout-minutes: 1
         shell: powershell
         # TODO(gustl22): Remove workaround of setting the time when virtual audio device certificate is valid again (#1573)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,19 +266,19 @@ jobs:
         run: |
           Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
           Expand-Archive -Path Scream.zip -DestinationPath Scream
-          Set-Date (Get-Date "2023-07-04 12:00:00")
+          Set-Date (Get-Date "2023-07-04 12:00:00"); $currentDate = Get-Date; Write-Host "Current Date: $currentDate";
           Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
           Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
           w32tm /resync /force; $currentDate = Get-Date; Write-Host "Current Date: $currentDate";
-      - name: Run Flutter integration tests
-        shell: powershell
-        working-directory: ./packages/audioplayers/example
-        # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
-        run: |
-          Start-Process -NoNewWindow -WorkingDirectory "server" dart -ArgumentList "run", "bin/server.dart"
-          flutter test -d windows integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test -d windows integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
-          flutter test -d windows integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
+#      - name: Run Flutter integration tests
+#        shell: powershell
+#        working-directory: ./packages/audioplayers/example
+#        # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
+#        run: |
+#          Start-Process -NoNewWindow -WorkingDirectory "server" dart -ArgumentList "run", "bin/server.dart"
+#          flutter test -d windows integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
+#          flutter test -d windows integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+#          flutter test -d windows integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Introduced in #1570. It seems that `Set-Data` in powershell not reliably is setting the time, or the system is not triggered to set the time. Probably a call to `Get-Time` triggers the system to update the time.

But this is just a theory. Anyways I ran multiple attempts, and in this PR this seems fixing the issue. I validated by enabling the timestamps in the GH runs.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
