### PR TITLE
ci: Enable server LIVE_MODE on Linux integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -306,10 +306,11 @@ jobs:
       - name: Run Flutter integration tests
         working-directory: ./packages/audioplayers/example
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
+        # TODO(gustl22): Linux tests are flaky with LIVE_MODE=false
         run: |
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          ( cd server; dart run bin/server.dart ) &
+          ( cd server; LIVE_MODE=true dart run bin/server.dart ) &
           flutter test -d linux integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
           flutter test -d linux integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
           flutter test -d linux integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true

--- a/packages/audioplayers/example/server/bin/server.dart
+++ b/packages/audioplayers/example/server/bin/server.dart
@@ -15,7 +15,20 @@ Future<void> main() async {
   final isLogRequests =
       (Platform.environment['LOG_REQUESTS'] ?? 'false') == 'true';
 
-  final cascade = Cascade().add(_staticHandler).add(_router);
+  final publicStaticHandler = shelf_static.createStaticHandler(
+    'public',
+    defaultDocument: 'index.html',
+    serveFilesOutsidePath: true,
+  );
+
+  final recordMode = bool.parse(Platform.environment['RECORD_MODE'] ?? 'false');
+  final liveMode =
+      recordMode || bool.parse(Platform.environment['LIVE_MODE'] ?? 'false');
+  final routeHandler = shelf_router.Router()
+    ..mount('/stream',
+        StreamRoute(isLiveMode: liveMode, isRecordMode: recordMode).pipeline);
+
+  final cascade = Cascade().add(publicStaticHandler).add(routeHandler);
 
   var pipeline = const Pipeline();
   if (isLogRequests) {
@@ -43,11 +56,3 @@ Future<void> main() async {
     'Serving at http://${server.address.host}:${server.port} with latency of $requestTimeoutMillis ms',
   );
 }
-
-final _staticHandler = shelf_static.createStaticHandler(
-  'public',
-  defaultDocument: 'index.html',
-  serveFilesOutsidePath: true,
-);
-
-final _router = shelf_router.Router()..mount('/stream', StreamRoute().pipeline);

--- a/packages/audioplayers/example/server/bin/stream_route.dart
+++ b/packages/audioplayers/example/server/bin/stream_route.dart
@@ -10,16 +10,15 @@ import 'package:shelf_router/shelf_router.dart';
 class StreamRoute {
   static const timesRadioUrl = 'https://timesradio.wireless.radio/stream';
   static const mpegRecordPath = 'public/files/live_streams/mpeg-record.bin';
-  static const _isLiveMode = false || _isRecordMode;
-  static const _isRecordMode = false;
 
   final mpegStreamController = StreamController<List<int>>.broadcast();
 
-  StreamRoute() : assert(!_isRecordMode || _isLiveMode) {
-    if (_isRecordMode) {
+  StreamRoute({bool isLiveMode = false, bool isRecordMode = false})
+      : assert(!isRecordMode || isLiveMode) {
+    if (isRecordMode) {
       recordLiveStream();
     }
-    if (_isLiveMode) {
+    if (isLiveMode) {
       playLiveStream();
     } else {
       playLocalStream();


### PR DESCRIPTION
# Description

Linux tests fail regularly (timeout), when testing mpga stream. So use live source instead of the prerecorded one.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

## Related Issues

#1604 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
