### PR TITLE
feat: create, dispose & reuse event stream

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,16 +260,17 @@ jobs:
       - uses: bluefireteam/melos-action@main
       - name: Start audio server
         run: net start audiosrv
-      # TODO(gustl22): Remove sound-ci-helpers and enable virtual audio device, when certificate is valid again (#1573)
-      - uses: LABSN/sound-ci-helpers@v1
-      #- name: Install virtual audio device
-      #  timeout-minutes: 1
-      #  shell: powershell
-      #  run: |
-      #    Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
-      #    Expand-Archive -Path Scream.zip -DestinationPath Scream
-      #    Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
-      #    Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
+      - name: Install virtual audio device
+        timeout-minutes: 1
+        shell: powershell
+        # TODO(gustl22): Remove workaround of setting the time when virtual audio device certificate is valid again (#1573)
+        run: |
+          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
+          Expand-Archive -Path Scream.zip -DestinationPath Scream
+          Set-Date (Get-Date "2023-07-04 12:00:00"); $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
+          Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
+          Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
+          w32tm /resync /force; $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
       - name: Run Flutter integration tests
         shell: powershell
         working-directory: ./packages/audioplayers/example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,17 +260,16 @@ jobs:
       - uses: bluefireteam/melos-action@main
       - name: Start audio server
         run: net start audiosrv
-      - name: Install virtual audio device
-        timeout-minutes: 1
-        shell: powershell
-        # TODO(gustl22): Remove workaround of setting the time when virtual audio device certificate is valid again (#1573)
-        run: |
-          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
-          Expand-Archive -Path Scream.zip -DestinationPath Scream
-          Set-Date (Get-Date "2023-07-04 12:00:00"); $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
-          Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
-          Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
-          w32tm /resync /force; $currentDate = Get-Date; Write-Host "Current System Date: $currentDate";
+      # TODO(gustl22): Remove sound-ci-helpers and enable virtual audio device, when certificate is valid again (#1573)
+      - uses: LABSN/sound-ci-helpers@v1
+      #- name: Install virtual audio device
+      #  timeout-minutes: 1
+      #  shell: powershell
+      #  run: |
+      #    Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
+      #    Expand-Archive -Path Scream.zip -DestinationPath Scream
+      #    Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
+      #    Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
       - name: Run Flutter integration tests
         shell: powershell
         working-directory: ./packages/audioplayers/example

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
@@ -12,6 +12,18 @@ import 'package:flutter/services.dart';
 class AudioplayersPlatform extends AudioplayersPlatformInterface
     with MethodChannelAudioplayersPlatform, EventChannelAudioplayersPlatform {
   AudioplayersPlatform();
+
+  @override
+  Future<void> create(String playerId) async {
+    await super.create(playerId);
+    createEventStream(playerId);
+  }
+
+  @override
+  Future<void> dispose(String playerId) async {
+    await super.dispose(playerId);
+    disposeEventStream(playerId);
+  }
 }
 
 mixin MethodChannelAudioplayersPlatform
@@ -212,12 +224,12 @@ mixin MethodChannelAudioplayersPlatform
 
 mixin EventChannelAudioplayersPlatform
     implements EventChannelAudioplayersPlatformInterface {
-  @override
-  Stream<AudioEvent> getEventStream(String playerId) {
-    // Only can be used after have created the event channel on the native side.
-    final eventChannel = EventChannel('xyz.luan/audioplayers/events/$playerId');
+  final Map<String, Stream<AudioEvent>> streams = {};
 
-    return eventChannel.receiveBroadcastStream().map(
+  // Only can be used after have created the event channel on the native side.
+  void createEventStream(String playerId) {
+    final eventChannel = EventChannel('xyz.luan/audioplayers/events/$playerId');
+    streams[playerId] = eventChannel.receiveBroadcastStream().map(
       (dynamic event) {
         final map = event as Map<dynamic, dynamic>;
         final eventType = map.getString('event');
@@ -259,5 +271,16 @@ mixin EventChannelAudioplayersPlatform
         }
       },
     );
+  }
+
+  void disposeEventStream(String playerId) {
+    if (streams.containsKey(playerId)) {
+      streams.remove(playerId);
+    }
+  }
+
+  @override
+  Stream<AudioEvent> getEventStream(String playerId) {
+    return streams[playerId]!;
   }
 }

--- a/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
@@ -13,14 +13,6 @@ void main() {
   final platform = AudioplayersPlatformInterface.instance;
 
   final methodCalls = <MethodCall>[];
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(
-    const MethodChannel('xyz.luan/audioplayers'),
-    (MethodCall methodCall) async {
-      methodCalls.add(methodCall);
-      return 0;
-    },
-  );
 
   void clear() {
     methodCalls.clear();
@@ -36,7 +28,24 @@ void main() {
   }
 
   group('AudioPlayers Method Channel', () {
-    setUp(clear);
+    setUp(() {
+      clear();
+
+      createNativeMethodHandler(
+        channel: 'xyz.luan/audioplayers',
+        handler: (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+          switch (methodCall.method) {
+            case 'getDuration':
+              return 0;
+            case 'getCurrentPosition':
+              return 0;
+            default:
+              return null;
+          }
+        },
+      );
+    });
 
     test('#setSource', () async {
       await platform.setSourceUrl('p1', 'internet.com/file.mp3');
@@ -83,14 +92,17 @@ void main() {
   group('AudioPlayers Event Channel', () {
     test('emit events', () async {
       final eventController = StreamController<ByteData>.broadcast();
+      const playerId = 'p1';
 
       createNativeEventStream(
-        channel: 'xyz.luan/audioplayers/events/p1',
+        channel: 'xyz.luan/audioplayers/events/$playerId',
         byteDataStream: eventController.stream,
       );
 
+      await platform.create(playerId);
+
       expect(
-        platform.getEventStream('p1'),
+        platform.getEventStream(playerId),
         emitsInOrder(<AudioEvent>[
           const AudioEvent(
             eventType: AudioEventType.duration,
@@ -140,6 +152,7 @@ void main() {
       }
 
       await eventController.close();
+      await platform.dispose(playerId);
     });
   });
 }

--- a/packages/audioplayers_platform_interface/test/global_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/global_platform_test.dart
@@ -30,16 +30,16 @@ void main() {
   }
 
   group('Global Method Channel', () {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      const MethodChannel('xyz.luan/audioplayers.global'),
-      (MethodCall methodCall) async {
-        methodCalls.add(methodCall);
-        return 1;
-      },
-    );
-
-    setUp(clear);
+    setUp(() {
+      clear();
+      createNativeMethodHandler(
+        channel: 'xyz.luan/audioplayers.global',
+        handler: (MethodCall methodCall) async {
+          methodCalls.add(methodCall);
+          return null;
+        },
+      );
+    });
 
     test('set AudioContext for Windows', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.windows;

--- a/packages/audioplayers_platform_interface/test/util.dart
+++ b/packages/audioplayers_platform_interface/test/util.dart
@@ -7,6 +7,17 @@ extension MethodCallParser on MethodCall {
   Map<Object?, Object?> get args => arguments as Map<Object?, Object?>;
 }
 
+void createNativeMethodHandler({
+  required String channel,
+  Future<Object?>? Function(MethodCall message)? handler,
+}) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    MethodChannel(channel),
+    handler,
+  );
+}
+
 // See: https://github.com/flutter/packages/blob/12609a2abbb0a30b9d32af7b73599bfc834e609e/packages/video_player/video_player_android/test/android_video_player_test.dart#L270
 void createNativeEventStream({
   required String channel,


### PR DESCRIPTION
# Description

Currently if an event stream for a `playerId` is requested, a new stream was created, conflicting with the existing one. Now the `createEventStream`, `disposeEventStream` and `getEventStream` methods allow more control of handling the stream and also reusing the existing stream on `getEventStream`. 

Info: this wasn't a problem so far, as one AudioPlayer only held one instance of an event stream. But this is problematic on requesting the stream multiple times on different levels in the tests.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
