### PR TITLE
feat(ios): Improved AudioContextConfig assertions, fix example

### DIFF
--- a/packages/audioplayers/example/lib/tabs/audio_context.dart
+++ b/packages/audioplayers/example/lib/tabs/audio_context.dart
@@ -3,6 +3,7 @@ import 'package:audioplayers_example/components/cbx.dart';
 import 'package:audioplayers_example/components/drop_down.dart';
 import 'package:audioplayers_example/components/tab_content.dart';
 import 'package:audioplayers_example/components/tabs.dart';
+import 'package:audioplayers_example/utils.dart';
 import 'package:flutter/material.dart';
 
 class AudioContextTab extends StatefulWidget {
@@ -82,10 +83,15 @@ class AudioContextTabState extends State<AudioContextTab>
   }
 
   void updateConfig(AudioContextConfig newConfig) {
-    setState(() {
-      audioContextConfig = newConfig;
-      audioContext = audioContextConfig.build();
-    });
+    try {
+      final context = newConfig.build();
+      setState(() {
+        audioContextConfig = newConfig;
+        audioContext = context;
+      });
+    } on AssertionError catch (e) {
+      toast(e.message.toString());
+    }
   }
 
   void updateAudioContextAndroid(AudioContextAndroid contextAndroid) {
@@ -94,10 +100,15 @@ class AudioContextTabState extends State<AudioContextTab>
     });
   }
 
-  void updateAudioContextIOS(AudioContextIOS contextIOS) {
-    setState(() {
-      audioContext = audioContext.copy(iOS: contextIOS);
-    });
+  void updateAudioContextIOS(AudioContextIOS Function() buildContextIOS) {
+    try {
+      final context = buildContextIOS();
+      setState(() {
+        audioContext = audioContext.copy(iOS: context);
+      });
+    } on AssertionError catch (e) {
+      toast(e.message.toString());
+    }
   }
 
   Widget _genericTab() {
@@ -194,19 +205,20 @@ class AudioContextTabState extends State<AudioContextTab>
   Widget _iosTab() {
     final iosOptions = AVAudioSessionOptions.values.map(
       (option) {
-        final options = audioContext.iOS.options;
+        final options = {...audioContext.iOS.options};
         return Cbx(
           option.name,
           value: options.contains(option),
           ({value}) {
-            if (value ?? false) {
-              options.add(option);
-            } else {
-              options.remove(option);
-            }
-            updateAudioContextIOS(
-              audioContext.iOS.copy(options: options),
-            );
+            updateAudioContextIOS(() {
+              final iosContext = audioContext.iOS.copy(options: options);
+              if (value ?? false) {
+                options.add(option);
+              } else {
+                options.remove(option);
+              }
+              return iosContext;
+            });
           },
         );
       },
@@ -219,7 +231,7 @@ class AudioContextTabState extends State<AudioContextTab>
           options: {for (final e in AVAudioSessionCategory.values) e: e.name},
           selected: audioContext.iOS.category,
           onChange: (v) => updateAudioContextIOS(
-            audioContext.iOS.copy(category: v),
+            () => audioContext.iOS.copy(category: v),
           ),
         ),
         ...iosOptions,

--- a/packages/audioplayers/example/lib/utils.dart
+++ b/packages/audioplayers/example/lib/utils.dart
@@ -7,7 +7,7 @@ extension StateExt<T extends StatefulWidget> on State<T> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message, key: textKey),
-        duration: const Duration(milliseconds: 250),
+        duration: Duration(milliseconds: message.length * 25),
       ),
     );
   }

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -99,8 +99,8 @@ class AudioContextConfig {
       usageType: respectSilence
           ? AndroidUsageType.notificationRingtone
           : (route == AudioContextConfigRoute.earpiece
-          ? AndroidUsageType.voiceCommunication
-          : AndroidUsageType.media),
+              ? AndroidUsageType.voiceCommunication
+              : AndroidUsageType.media),
       audioFocus: duckAudio
           ? AndroidAudioFocus.gainTransientMayDuck
           : AndroidAudioFocus.gain,
@@ -116,10 +116,10 @@ class AudioContextConfig {
         category: respectSilence
             ? AVAudioSessionCategory.ambient
             : (route == AudioContextConfigRoute.speaker
-            ? AVAudioSessionCategory.playAndRecord
-            : (route == AudioContextConfigRoute.earpiece
-            ? AVAudioSessionCategory.playAndRecord
-            : AVAudioSessionCategory.playback)),
+                ? AVAudioSessionCategory.playAndRecord
+                : (route == AudioContextConfigRoute.earpiece
+                    ? AVAudioSessionCategory.playAndRecord
+                    : AVAudioSessionCategory.playback)),
         options: {
           if (duckAudio) AVAudioSessionOptions.duckOthers,
           if (route == AudioContextConfigRoute.speaker)
@@ -130,14 +130,19 @@ class AudioContextConfig {
       // Please create a custom [AudioContextIOS] if the generic flags cannot
       // represent your needs.
       throw AssertionError(
-          'Invalid AudioContextConfig on iOS platform: ['
-              'route: $route, '
-              'duckAudio: $duckAudio, '
-              'respectSilence: $respectSilence, '
-              'stayAwake: $stayAwake]. \n'
-              'Details: ${e.message}'
-      );
+          'Invalid AudioContextConfig on iOS platform: ${toString()}\n'
+          'Details: ${e.message}');
     }
+  }
+
+  @override
+  String toString() {
+    return 'AudioContextConfig('
+        'route: $route, '
+        'duckAudio: $duckAudio, '
+        'respectSilence: $respectSilence, '
+        'stayAwake: $stayAwake'
+        ')';
   }
 }
 

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -111,28 +111,36 @@ class AudioContextConfig {
     if (defaultTargetPlatform != TargetPlatform.iOS) {
       return null;
     }
-    try {
-      return AudioContextIOS(
-        category: respectSilence
-            ? AVAudioSessionCategory.ambient
-            : (route == AudioContextConfigRoute.speaker
-                ? AVAudioSessionCategory.playAndRecord
-                : (route == AudioContextConfigRoute.earpiece
-                    ? AVAudioSessionCategory.playAndRecord
-                    : AVAudioSessionCategory.playback)),
-        options: {
-          if (duckAudio) AVAudioSessionOptions.duckOthers,
-          if (route == AudioContextConfigRoute.speaker)
-            AVAudioSessionOptions.defaultToSpeaker,
-        },
-      );
-    } on AssertionError catch (e) {
-      // Please create a custom [AudioContextIOS] if the generic flags cannot
-      // represent your needs.
-      throw AssertionError(
-          'Invalid AudioContextConfig on iOS platform: ${toString()}\n'
-          'Details: ${e.message}');
-    }
+    validateIOS();
+    return AudioContextIOS(
+      category: respectSilence
+          ? AVAudioSessionCategory.ambient
+          : (route == AudioContextConfigRoute.speaker
+              ? AVAudioSessionCategory.playAndRecord
+              : (route == AudioContextConfigRoute.earpiece
+                  ? AVAudioSessionCategory.playAndRecord
+                  : AVAudioSessionCategory.playback)),
+      options: {
+        if (duckAudio) AVAudioSessionOptions.duckOthers,
+        if (route == AudioContextConfigRoute.speaker)
+          AVAudioSessionOptions.defaultToSpeaker,
+      },
+    );
+  }
+
+  void validateIOS() {
+    const invalidMsg =
+        'Invalid AudioContextConfig: On iOS it is not possible to set';
+    const tip = 'Please create a custom [AudioContextIOS] if the generic flags '
+        'cannot represent your needs.';
+    assert(
+      !(duckAudio && respectSilence),
+      '$invalidMsg `respectSilence` and `duckAudio`. $tip',
+    );
+    assert(
+      !(respectSilence && route == AudioContextConfigRoute.speaker),
+      '$invalidMsg `respectSilence` and route `speaker`. $tip',
+    );
   }
 
   @override

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -99,40 +99,44 @@ class AudioContextConfig {
       usageType: respectSilence
           ? AndroidUsageType.notificationRingtone
           : (route == AudioContextConfigRoute.earpiece
-              ? AndroidUsageType.voiceCommunication
-              : AndroidUsageType.media),
+          ? AndroidUsageType.voiceCommunication
+          : AndroidUsageType.media),
       audioFocus: duckAudio
           ? AndroidAudioFocus.gainTransientMayDuck
           : AndroidAudioFocus.gain,
     );
   }
 
-  AudioContextIOS buildIOS() {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      validateIOS();
+  AudioContextIOS? buildIOS() {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return null;
     }
-    return AudioContextIOS(
-      category: respectSilence
-          ? AVAudioSessionCategory.ambient
-          : (route == AudioContextConfigRoute.speaker
-              ? AVAudioSessionCategory.playAndRecord
-              : (route == AudioContextConfigRoute.earpiece
-                  ? AVAudioSessionCategory.playAndRecord
-                  : AVAudioSessionCategory.playback)),
-      options: {
-        if (duckAudio) AVAudioSessionOptions.duckOthers,
-        if (route == AudioContextConfigRoute.speaker)
-          AVAudioSessionOptions.defaultToSpeaker,
-      },
-    );
-  }
-
-  void validateIOS() {
-    // Please create a custom [AudioContextIOS] if the generic flags cannot
-    // represent your needs.
-    if (respectSilence && route == AudioContextConfigRoute.speaker) {
-      throw 'On iOS it is impossible to set both `respectSilence` and route '
-          '`speaker`';
+    try {
+      return AudioContextIOS(
+        category: respectSilence
+            ? AVAudioSessionCategory.ambient
+            : (route == AudioContextConfigRoute.speaker
+            ? AVAudioSessionCategory.playAndRecord
+            : (route == AudioContextConfigRoute.earpiece
+            ? AVAudioSessionCategory.playAndRecord
+            : AVAudioSessionCategory.playback)),
+        options: {
+          if (duckAudio) AVAudioSessionOptions.duckOthers,
+          if (route == AudioContextConfigRoute.speaker)
+            AVAudioSessionOptions.defaultToSpeaker,
+        },
+      );
+    } on AssertionError catch (e) {
+      // Please create a custom [AudioContextIOS] if the generic flags cannot
+      // represent your needs.
+      throw AssertionError(
+          'Invalid AudioContextConfig on iOS platform: ['
+              'route: $route, '
+              'duckAudio: $duckAudio, '
+              'respectSilence: $respectSilence, '
+              'stayAwake: $stayAwake]. \n'
+              'Details: ${e.message}'
+      );
     }
   }
 }

--- a/packages/audioplayers_platform_interface/test/audio_context_test.dart
+++ b/packages/audioplayers_platform_interface/test/audio_context_test.dart
@@ -1,6 +1,8 @@
 //ignore_for_file: avoid_redundant_argument_values
 
 import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
+import 'package:audioplayers_platform_interface/src/api/audio_context_config.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -24,6 +26,68 @@ void main() {
           options: const {},
         ),
       ),
+    );
+  });
+
+  test('Compare AudioContextConfig with AudioContext', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    const boolValues = {true, false};
+    const routeValues = AudioContextConfigRoute.values;
+
+    final throwsAssertion = [];
+    for (final isDuckAudio in boolValues) {
+      for (final isRespectSilence in boolValues) {
+        for (final isStayAwake in boolValues) {
+          for (final route in routeValues) {
+            final config = AudioContextConfig(
+              duckAudio: isDuckAudio,
+              respectSilence: isRespectSilence,
+              stayAwake: isStayAwake,
+              route: route,
+            );
+            try {
+              config.build();
+              throwsAssertion.add(false);
+            } on AssertionError catch (e) {
+              // if(e.startsWith('...')) {}
+              throwsAssertion.add(true);
+              print('#########');
+              print(e);
+            }
+          }
+        }
+      }
+    }
+
+    // Ensure assertions keep thrown on the correct cases.
+    expect(
+      throwsAssertion,
+      const [
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
     );
   });
 

--- a/packages/audioplayers_platform_interface/test/audio_context_test.dart
+++ b/packages/audioplayers_platform_interface/test/audio_context_test.dart
@@ -29,7 +29,7 @@ void main() {
     );
   });
 
-  test('Compare AudioContextConfig with AudioContext', () async {
+  test('Check AudioContextConfig assertions', () async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     const boolValues = {true, false};
     const routeValues = AudioContextConfigRoute.values;
@@ -49,10 +49,16 @@ void main() {
               config.build();
               throwsAssertion.add(false);
             } on AssertionError catch (e) {
-              // if(e.startsWith('...')) {}
-              throwsAssertion.add(true);
-              print('#########');
-              print(e);
+              if (e.message
+                  .toString()
+                  .startsWith('Invalid AudioContextConfig')) {
+                throwsAssertion.add(true);
+              } else {
+                fail(
+                  'Assertion of $config does not match the expected '
+                  'description. See: $e',
+                );
+              }
             }
           }
         }
@@ -86,7 +92,7 @@ void main() {
         false,
         false,
         false,
-        false
+        false,
       ],
     );
   });


### PR DESCRIPTION
# Description

- Improve assertion error messages for `AudioContextConfig` for values set on iOS
- Fix example, as it could and should not alternate the `options` array for AudioContextIOS
- Improve example to show assertion errors as toast to the user

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
