### PR TITLE
Enabling to use Asset source without adding it a prefix

### DIFF
--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -75,7 +75,7 @@ class AudioCache {
   @visibleForTesting
   Future<String> getTempDir() async => (await getTemporaryDirectory()).path;
 
-  Future<Uri> fetchToMemory(String fileName) async {
+  Future<Uri> fetchToMemory(String fileName, {bool withPrefix = true}) async {
     if (kIsWeb) {
       final uri = _sanitizeURLForWeb(fileName);
       // We rely on browser caching here. Once the browser downloads this file,
@@ -85,7 +85,8 @@ class AudioCache {
     }
 
     // read local asset from rootBundle
-    final byteData = await loadAsset('$prefix$fileName');
+    final byteData =
+        await loadAsset(withPrefix ? '$prefix$fileName' : fileName);
 
     // create a temporary file on the device to be read by the native side
     final file = fileSystem.file('${await getTempDir()}/$fileName');
@@ -109,9 +110,10 @@ class AudioCache {
   /// Loads a single [fileName] to the cache.
   ///
   /// Also returns a [Future] to access that file.
-  Future<Uri> load(String fileName) async {
+  Future<Uri> load(String fileName, {bool withPrefix = true}) async {
     if (!loadedFiles.containsKey(fileName)) {
-      loadedFiles[fileName] = await fetchToMemory(fileName);
+      loadedFiles[fileName] =
+          await fetchToMemory(fileName, withPrefix: withPrefix);
     }
     return loadedFiles[fileName]!;
   }

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -347,9 +347,9 @@ class AudioPlayer {
   ///
   /// The resources will start being fetched or buffered as soon as you call
   /// this method.
-  Future<void> setSourceAsset(String path) async {
+  Future<void> setSourceAsset(String path, {bool withPrefix = true}) async {
     _source = AssetSource(path);
-    final url = await audioCache.load(path);
+    final url = await audioCache.load(path, withPrefix: withPrefix);
     await creatingCompleter.future;
     await _completePrepared(
       () => _platform.setSourceUrl(playerId, url.path, isLocal: true),

--- a/packages/audioplayers/lib/src/source.dart
+++ b/packages/audioplayers/lib/src/source.dart
@@ -50,12 +50,16 @@ class DeviceFileSource extends Source {
 /// instance.
 class AssetSource extends Source {
   final String path;
+  final bool withPrefix;
 
-  AssetSource(this.path);
+  AssetSource(
+    this.path, {
+    this.withPrefix = true,
+  });
 
   @override
   Future<void> setOnPlayer(AudioPlayer player) {
-    return player.setSourceAsset(path);
+    return player.setSourceAsset(path, withPrefix: withPrefix);
   }
 
   @override


### PR DESCRIPTION
This is useful in multiple cases. The most evident one is for use Assets inside a dependency package with a prefix like this: "packages/PACKAGE_NAME/..."
