### PR TITLE
Audioplayer null fix

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -125,7 +125,7 @@ class AudioPlayer {
 
   Stream<bool> get _onPrepared => eventStream
       .where((event) => event.eventType == AudioEventType.prepared)
-      .map((event) => event.isPrepared!);
+      .map((event) => event.isPrepared ?? false);
 
   /// Stream of log events.
   Stream<String> get onLog => eventStream

--- a/packages/audioplayers/test/global_audioplayers_test.dart
+++ b/packages/audioplayers/test/global_audioplayers_test.dart
@@ -33,13 +33,13 @@ void main() {
     /// If using [AVAudioSessionCategory.playAndRecord] the audio will come from
     /// the earpiece unless [AVAudioSessionOptions.defaultToSpeaker] is used.
     test('set AudioContext', () async {
-      await globalScope.setAudioContext(AudioContext());
+      await globalScope.setAudioContext(const AudioContext());
       final call = globalPlatform.popLastCall();
       expect(call.method, 'setGlobalAudioContext');
       expect(
         call.value,
-        AudioContext(
-          android: const AudioContextAndroid(
+        const AudioContext(
+          android: AudioContextAndroid(
             isSpeakerphoneOn: false,
             audioMode: AndroidAudioMode.normal,
             stayAwake: false,
@@ -49,7 +49,7 @@ void main() {
           ),
           iOS: AudioContextIOS(
             category: AVAudioSessionCategory.playback,
-            options: const {},
+            options: [],
           ),
         ),
       );


### PR DESCRIPTION
# Description

This change fixes null error from native channel Related issue #1640 

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

Fixes #1640 

