### PR TITLE
fix: Set playback rate only when playing

### DIFF
--- a/packages/audioplayers/example/integration_test/platform_test.dart
+++ b/packages/audioplayers/example/integration_test/platform_test.dart
@@ -181,6 +181,18 @@ void main() async {
       }
     }
 
+    testWidgets('Avoid resume on setting playbackRate (#468)', (tester) async {
+      await tester.prepareSource(
+        playerId: playerId,
+        platform: platform,
+        testData: mp3Url1TestData,
+      );
+      await platform.setPlaybackRate(playerId, 2.0);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(await platform.getCurrentPosition(playerId), 0);
+      await tester.pumpLinux();
+    });
+
     for (final td in audioTestDataList) {
       if (features.hasSeek && !td.isLiveStream) {
         testWidgets('#seek with millisecond precision ${td.source}',

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
@@ -43,7 +43,9 @@ class MediaPlayerPlayer(
     override fun setRate(rate: Float) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             mediaPlayer.playbackParams = mediaPlayer.playbackParams.setSpeed(rate)
-        } else if (rate != 1.0f) {
+        } else if (rate == 1.0f) {
+            mediaPlayer.start()
+        } else {
             error("Changing the playback rate is only available for Android M/23+ or using LOW_LATENCY mode.")
         }
     }
@@ -58,7 +60,8 @@ class MediaPlayerPlayer(
     }
 
     override fun start() {
-        mediaPlayer.start()
+        // Setting playback rate instead of mediaPlayer.start().
+        setRate(wrappedPlayer.rate)
     }
 
     override fun pause() {

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -67,7 +67,9 @@ class WrappedPlayer internal constructor(
         set(value) {
             if (field != value) {
                 field = value
-                player?.setRate(value)
+                if (playing) {
+                    player?.setRate(value)
+                }
             }
         }
 
@@ -364,7 +366,6 @@ class WrappedPlayer internal constructor(
     }
 
     private fun Player.configAndPrepare() {
-        setRate(rate)
         setVolumeAndBalance(volume, balance)
         setLooping(isLooping)
         prepare()

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -114,10 +114,10 @@ class WrappedMediaPlayer {
 
   func setPlaybackRate(playbackRate: Double) {
     self.playbackRate = playbackRate
-    //if isPlaying {
+    if isPlaying {
       // Setting the rate causes the player to resume playing. So setting it only, when already playing.
       player.rate = Float(playbackRate)
-    //}
+    }
   }
 
   func seek(time: CMTime, completer: Completer? = nil) {

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -114,10 +114,10 @@ class WrappedMediaPlayer {
 
   func setPlaybackRate(playbackRate: Double) {
     self.playbackRate = playbackRate
-    if isPlaying {
+    //if isPlaying {
       // Setting the rate causes the player to resume playing. So setting it only, when already playing.
       player.rate = Float(playbackRate)
-    }
+    //}
   }
 
   func seek(time: CMTime, completer: Completer? = nil) {

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -114,7 +114,10 @@ class WrappedMediaPlayer {
 
   func setPlaybackRate(playbackRate: Double) {
     self.playbackRate = playbackRate
-    player.rate = Float(playbackRate)
+    if isPlaying {
+      // Setting the rate causes the player to resume playing. So setting it only, when already playing.
+      player.rate = Float(playbackRate)
+    }
   }
 
   func seek(time: CMTime, completer: Completer? = nil) {


### PR DESCRIPTION
# Description

Fixes #468

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
