### PR TITLE
feat!: FramePositionUpdater & TimerPositionUpdater

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -333,3 +333,15 @@ If you want to specify the playerId, you can do so when creating the playing:
 ```
 
 Two players with the same id will point to the same media player on the native side.
+
+### PositionUpdater
+
+By default, the position stream is updated on every new frame. You can change this behavior to e.g. update on a certain
+interval with the `TimerPositionUpdater` or implement your own `PositionUpdater`:
+
+```dart
+  player.positionUpdater = TimerPositionUpdater(
+    interval: const Duration(milliseconds: 100),
+    getPosition: player.getCurrentPosition,
+  );
+```

--- a/packages/audioplayers/example/integration_test/app/app_test_utils.dart
+++ b/packages/audioplayers/example/integration_test/app/app_test_utils.dart
@@ -123,7 +123,7 @@ $lastFailureMsg''',
         scrollable: find.byType(Scrollable).first,
       );
     }
-    await pumpAndSettle();
+    await pump();
   }
 }
 

--- a/packages/audioplayers/example/integration_test/app/tabs/controls_tab.dart
+++ b/packages/audioplayers/example/integration_test/app/tabs/controls_tab.dart
@@ -148,7 +148,7 @@ Future<void> testControlsTab(
 extension ControlsWidgetTester on WidgetTester {
   Future<void> resume() async {
     await scrollToAndTap(const Key('control-resume'));
-    await pumpAndSettle();
+    await pump();
   }
 
   Future<void> stop() async {
@@ -156,7 +156,7 @@ extension ControlsWidgetTester on WidgetTester {
 
     await scrollToAndTap(const Key('control-stop'));
     await waitOneshot(const Key('toast-player-stopped-0'), stackTrace: st);
-    await pumpAndSettle();
+    await pump();
   }
 
   Future<void> testVolume(

--- a/packages/audioplayers/example/integration_test/app/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/app/tabs/stream_tab.dart
@@ -33,7 +33,7 @@ Future<void> testStreamsTab(
 
   await tester.pumpAndSettle();
   await tester.scrollToAndTap(const Key('play_button'));
-  await tester.pumpAndSettle();
+  await tester.pump();
 
   // Cannot test more precisely as it is dependent on pollInterval
   // and updateInterval of native implementation.
@@ -122,13 +122,6 @@ extension StreamWidgetTester on WidgetTester {
   // Linux: millisecond
   // Web: millisecond
   // Darwin: millisecond
-
-  // Update interval for position:
-  // Android: ~200ms
-  // Windows: ~250ms
-  // Linux: ~250ms
-  // Web: ~250ms
-  // Darwin: ~200ms
 
   Future<void> stopStream() async {
     final st = StackTrace.current.toString();

--- a/packages/audioplayers/example/integration_test/app/tabs/stream_tab.dart
+++ b/packages/audioplayers/example/integration_test/app/tabs/stream_tab.dart
@@ -18,7 +18,7 @@ Future<void> testStreamsTab(
   await tester.pumpAndSettle();
 
   // Stream position is tracked as soon as source is loaded
-  if (features.hasPositionEvent && !audioSourceTestData.isLiveStream) {
+  if (!audioSourceTestData.isLiveStream) {
     // Display position before playing
     await tester.testPosition(Duration.zero);
   }
@@ -47,18 +47,16 @@ Future<void> testStreamsTab(
     }
 
     // Test if onPositionText is set.
-    if (features.hasPositionEvent) {
-      await tester.testPosition(
-        Duration.zero,
-        matcher: (Duration? position) => greaterThan(position ?? Duration.zero),
-        timeout: timeout,
-      );
-      await tester.testOnPosition(
-        Duration.zero,
-        matcher: greaterThan,
-        timeout: timeout,
-      );
-    }
+    await tester.testPosition(
+      Duration.zero,
+      matcher: (Duration? position) => greaterThan(position ?? Duration.zero),
+      timeout: timeout,
+    );
+    await tester.testOnPosition(
+      Duration.zero,
+      matcher: greaterThan,
+      timeout: timeout,
+    );
   }
 
   if (features.hasDurationEvent && !audioSourceTestData.isLiveStream) {
@@ -110,7 +108,7 @@ Future<void> testStreamsTab(
       );
     }
   }
-  if (features.hasPositionEvent && !audioSourceTestData.isLiveStream) {
+  if (!audioSourceTestData.isLiveStream) {
     await tester.testPosition(Duration.zero);
   }
 }

--- a/packages/audioplayers/example/integration_test/lib/lib_test_utils.dart
+++ b/packages/audioplayers/example/integration_test/lib/lib_test_utils.dart
@@ -8,4 +8,19 @@ extension LibWidgetTester on WidgetTester {
       await pump();
     }
   }
+
+  /// See [pumpFrames].
+  Future<void> pumpGlobalFrames(
+    Duration maxDuration, [
+    Duration interval = const Duration(milliseconds: 16, microseconds: 683),
+  ]) {
+    var elapsed = Duration.zero;
+    return TestAsyncUtils.guard<void>(() async {
+      binding.scheduleFrame();
+      while (elapsed < maxDuration) {
+        await binding.pump(interval);
+        elapsed += interval;
+      }
+    });
+  }
 }

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -95,8 +95,11 @@ void main() async {
       LibSourceTestData td, {
       bool useTimerPositionUpdater = false,
     }) {
+      final positionUpdaterName = useTimerPositionUpdater
+          ? 'TimerPositionUpdater'
+          : 'FramePositionUpdater';
       testWidgets(
-        '#positionEvent ${td.source}',
+        '#positionEvent with $positionUpdaterName: ${td.source}',
         (tester) async {
           await tester.pumpLinux();
 

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -92,7 +92,6 @@ class PlatformFeatures {
   final bool hasPlayingRoute; // Not yet tested
 
   final bool hasDurationEvent;
-  final bool hasPositionEvent;
   final bool hasPlayerStateEvent;
   final bool hasErrorEvent; // Not yet tested
 
@@ -116,7 +115,6 @@ class PlatformFeatures {
     this.hasRecordingActive = true,
     this.hasPlayingRoute = true,
     this.hasDurationEvent = true,
-    this.hasPositionEvent = true,
     this.hasPlayerStateEvent = true,
     this.hasErrorEvent = true,
   });

--- a/packages/audioplayers/lib/audioplayers.dart
+++ b/packages/audioplayers/lib/audioplayers.dart
@@ -12,4 +12,5 @@ export 'src/audio_logger.dart';
 export 'src/audio_pool.dart';
 export 'src/audioplayer.dart';
 export 'src/global_audio_scope.dart';
+export 'src/position_updater.dart';
 export 'src/source.dart';

--- a/packages/audioplayers/lib/src/position_updater.dart
+++ b/packages/audioplayers/lib/src/position_updater.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+
+abstract class PositionUpdater {
+  /// You can use `player.getCurrentPosition` as the [getPosition] parameter.
+  PositionUpdater({
+    required this.getPosition,
+  });
+
+  final Future<Duration?> Function() getPosition;
+  final _streamController = StreamController<Duration>.broadcast();
+
+  Stream<Duration> get positionStream => _streamController.stream;
+
+  Future<void> update() async {
+    final position = await getPosition();
+    if (position != null) {
+      _streamController.add(position);
+    }
+  }
+
+  void start();
+
+  void stop();
+
+  Future<void> stopAndUpdate() async {
+    stop();
+    await update();
+  }
+
+  Future<void> dispose() async {
+    stop();
+    await _streamController.close();
+  }
+}
+
+class TimerPositionUpdater extends PositionUpdater {
+  Timer? _positionStreamTimer;
+  final Duration interval;
+
+  /// Position stream will be updated in the according [interval].
+  TimerPositionUpdater({
+    required super.getPosition,
+    required this.interval,
+  });
+
+  @override
+  void start() {
+    _positionStreamTimer?.cancel();
+    _positionStreamTimer = Timer.periodic(interval, (timer) async {
+      await update();
+    });
+  }
+
+  @override
+  void stop() {
+    _positionStreamTimer?.cancel();
+    _positionStreamTimer = null;
+  }
+}
+
+class FramePositionUpdater extends PositionUpdater {
+  int? _frameCallbackId;
+  bool _isRunning = false;
+
+  /// Position stream will be updated at every new frame.
+  FramePositionUpdater({
+    required super.getPosition,
+  });
+
+  void _tick(Duration? timestamp) {
+    if (_isRunning) {
+      update();
+      _frameCallbackId = SchedulerBinding.instance.scheduleFrameCallback(_tick);
+    }
+  }
+
+  @override
+  void start() {
+    _isRunning = true;
+    _tick(null);
+  }
+
+  @override
+  void stop() {
+    _isRunning = false;
+    if (_frameCallbackId != null) {
+      SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackId!);
+    }
+  }
+}

--- a/packages/audioplayers/test/audioplayers_test.dart
+++ b/packages/audioplayers/test/audioplayers_test.dart
@@ -17,6 +17,8 @@ void main() {
     required String playerId,
   }) async {
     final player = AudioPlayer(playerId: playerId);
+    // Avoid unpredictable position updates
+    player.positionUpdater = null;
     expect(player.source, null);
     await player.creatingCompleter.future;
     expect(platform.popCall().method, 'create');
@@ -51,8 +53,7 @@ void main() {
       final call1 = platform.popCall();
       expect(call1.method, 'setSourceUrl');
       expect(call1.value, 'internet.com/file.mp3');
-      final call2 = platform.popLastCall();
-      expect(call2.method, 'resume');
+      expect(platform.popLastCall().method, 'resume');
     });
 
     test('multiple players', () async {
@@ -63,8 +64,7 @@ void main() {
       expect(call1.id, 'p1');
       expect(call1.method, 'setSourceUrl');
       expect(call1.value, 'internet.com/file.mp3');
-      final call2 = platform.popLastCall();
-      expect(call2.method, 'resume');
+      expect(platform.popLastCall().method, 'resume');
 
       platform.clear();
       await player.play(UrlSource('internet.com/file.mp3'));
@@ -130,10 +130,6 @@ void main() {
         const AudioEvent(
           eventType: AudioEventType.duration,
           duration: Duration(milliseconds: 98765),
-        ),
-        const AudioEvent(
-          eventType: AudioEventType.position,
-          position: Duration(milliseconds: 8765),
         ),
         const AudioEvent(
           eventType: AudioEventType.log,

--- a/packages/audioplayers/test/fake_audioplayers_platform.dart
+++ b/packages/audioplayers/test/fake_audioplayers_platform.dart
@@ -10,6 +10,9 @@ class FakeCall {
   final Object? value;
 
   FakeCall({required this.id, required this.method, this.value});
+
+  @override
+  String toString() => 'FakeCall(id: $id, method: $method, value: $value)';
 }
 
 class FakeAudioplayersPlatform extends AudioplayersPlatformInterface {

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -3,32 +3,22 @@ package xyz.luan.audioplayers
 import android.content.Context
 import android.media.AudioManager
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import xyz.luan.audioplayers.player.SoundPoolManager
 import xyz.luan.audioplayers.player.WrappedPlayer
 import xyz.luan.audioplayers.source.BytesSource
 import xyz.luan.audioplayers.source.UrlSource
 import java.io.FileNotFoundException
-import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
 
 typealias FlutterHandler = (call: MethodCall, response: MethodChannel.Result) -> Unit
 
-class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
-    private val mainScope = CoroutineScope(Dispatchers.Main)
-
+class AudioplayersPlugin : FlutterPlugin {
     private lateinit var methods: MethodChannel
     private lateinit var globalMethods: MethodChannel
     private lateinit var globalEvents: EventHandler
@@ -37,9 +27,6 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
     private lateinit var soundPoolManager: SoundPoolManager
 
     private val players = ConcurrentHashMap<String, WrappedPlayer>()
-    private val handler = Handler(Looper.getMainLooper())
-    private var updateRunnable: Runnable? = null
-
     private var defaultAudioContext = AudioContextAndroid()
 
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
@@ -50,17 +37,12 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
         methods.setMethodCallHandler { call, response -> safeCall(call, response, ::methodHandler) }
         globalMethods = MethodChannel(binding.binaryMessenger, "xyz.luan/audioplayers.global")
         globalMethods.setMethodCallHandler { call, response -> safeCall(call, response, ::globalMethodHandler) }
-        updateRunnable = UpdateRunnable(players, methods, handler, this)
         globalEvents = EventHandler(EventChannel(binding.binaryMessenger, "xyz.luan/audioplayers.global/events"))
     }
 
     override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
-        stopUpdates()
-        handler.removeCallbacksAndMessages(null)
-        updateRunnable = null
         players.values.forEach { it.dispose() }
         players.clear()
-        mainScope.cancel()
         soundPoolManager.dispose()
         globalEvents.dispose()
     }
@@ -70,12 +52,10 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
         response: MethodChannel.Result,
         handler: FlutterHandler,
     ) {
-        mainScope.launch(Dispatchers.IO) {
-            try {
-                handler(call, response)
-            } catch (e: Exception) {
-                response.error("Unexpected AndroidAudioError", e.message, e)
-            }
+        try {
+            handler(call, response)
+        } catch (e: Exception) {
+            response.error("Unexpected AndroidAudioError", e.message, e)
         }
     }
 
@@ -205,10 +185,8 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
                 }
 
                 "dispose" -> {
-                    handler.post {
-                        player.dispose()
-                        players.remove(playerId)
-                    }
+                    player.dispose()
+                    players.remove(playerId)
                 }
 
                 else -> {
@@ -234,102 +212,40 @@ class AudioplayersPlugin : FlutterPlugin, IUpdateCallback {
         return context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     }
 
-    fun handleIsPlaying() {
-        startUpdates()
-    }
-
     fun handleDuration(player: WrappedPlayer) {
-        handler.post {
-            player.eventHandler.success(
-                "audio.onDuration",
-                hashMapOf("value" to (player.getDuration() ?: 0)),
-            )
-        }
+        player.eventHandler.success(
+            "audio.onDuration",
+            hashMapOf("value" to (player.getDuration() ?: 0)),
+        )
     }
 
     fun handleComplete(player: WrappedPlayer) {
-        handler.post { player.eventHandler.success("audio.onComplete") }
+        player.eventHandler.success("audio.onComplete")
     }
 
     fun handlePrepared(player: WrappedPlayer, isPrepared: Boolean) {
-        handler.post { player.eventHandler.success("audio.onPrepared", hashMapOf("value" to isPrepared)) }
+        player.eventHandler.success("audio.onPrepared", hashMapOf("value" to isPrepared))
     }
 
     fun handleLog(player: WrappedPlayer, message: String) {
-        handler.post { player.eventHandler.success("audio.onLog", hashMapOf("value" to message)) }
+        player.eventHandler.success("audio.onLog", hashMapOf("value" to message))
     }
 
     fun handleGlobalLog(message: String) {
-        handler.post { globalEvents.success("audio.onLog", hashMapOf("value" to message)) }
+        globalEvents.success("audio.onLog", hashMapOf("value" to message))
     }
 
     fun handleError(player: WrappedPlayer, errorCode: String?, errorMessage: String?, errorDetails: Any?) {
-        handler.post { player.eventHandler.error(errorCode, errorMessage, errorDetails) }
+        player.eventHandler.error(errorCode, errorMessage, errorDetails)
     }
 
     fun handleGlobalError(errorCode: String?, errorMessage: String?, errorDetails: Any?) {
-        handler.post { globalEvents.error(errorCode, errorMessage, errorDetails) }
+        globalEvents.error(errorCode, errorMessage, errorDetails)
     }
 
     fun handleSeekComplete(player: WrappedPlayer) {
-        handler.post {
-            player.eventHandler.success("audio.onSeekComplete")
-            player.eventHandler.success(
-                "audio.onCurrentPosition",
-                hashMapOf("value" to (player.getCurrentPosition() ?: 0)),
-            )
-        }
+        player.eventHandler.success("audio.onSeekComplete")
     }
-
-    override fun startUpdates() {
-        updateRunnable?.let { handler.post(it) }
-    }
-
-    override fun stopUpdates() {
-        updateRunnable?.let { handler.removeCallbacks(it) }
-    }
-
-    private class UpdateRunnable(
-        mediaPlayers: ConcurrentMap<String, WrappedPlayer>,
-        methodChannel: MethodChannel,
-        handler: Handler,
-        updateCallback: IUpdateCallback,
-    ) : Runnable {
-        private val mediaPlayers = WeakReference(mediaPlayers)
-        private val methodChannel = WeakReference(methodChannel)
-        private val handler = WeakReference(handler)
-        private val updateCallback = WeakReference(updateCallback)
-
-        override fun run() {
-            val mediaPlayers = mediaPlayers.get()
-            val channel = methodChannel.get()
-            val handler = handler.get()
-            val updateCallback = updateCallback.get()
-            if (mediaPlayers == null || channel == null || handler == null || updateCallback == null) {
-                updateCallback?.stopUpdates()
-                return
-            }
-            var isAnyPlaying = false
-            for (player in mediaPlayers.values) {
-                if (!player.isActuallyPlaying()) {
-                    continue
-                }
-                isAnyPlaying = true
-                val time = player.getCurrentPosition()
-                player.eventHandler.success("audio.onCurrentPosition", hashMapOf("value" to (time ?: 0)))
-            }
-            if (isAnyPlaying) {
-                handler.postDelayed(this, 200)
-            } else {
-                updateCallback.stopUpdates()
-            }
-        }
-    }
-}
-
-private interface IUpdateCallback {
-    fun stopUpdates()
-    fun startUpdates()
 }
 
 private inline fun <reified T : Enum<T>> MethodCall.enumArgument(name: String): T? {

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerPlayer.kt
@@ -32,10 +32,6 @@ class MediaPlayerPlayer(
         return mediaPlayer.currentPosition
     }
 
-    override fun isActuallyPlaying(): Boolean {
-        return mediaPlayer.isPlaying
-    }
-
     override fun setVolume(leftVolume: Float, rightVolume: Float) {
         mediaPlayer.setVolume(leftVolume, rightVolume)
     }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/Player.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/Player.kt
@@ -6,7 +6,6 @@ import xyz.luan.audioplayers.source.Source
 interface Player {
     fun getDuration(): Int?
     fun getCurrentPosition(): Int?
-    fun isActuallyPlaying(): Boolean
     fun isLiveStream(): Boolean
 
     fun start()

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/SoundPoolPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/SoundPoolPlayer.kt
@@ -126,7 +126,8 @@ class SoundPoolPlayer(
                                 soundId = intSoundId
 
                                 wrappedPlayer.handleLog(
-                                    "time to call load() for $value: ${System.currentTimeMillis() - start} player=$this",
+                                    "time to call load() for $value: " +
+                                        "${System.currentTimeMillis() - start} player=$this",
                                 )
                             }
                         }

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -182,10 +182,6 @@ class WrappedPlayer internal constructor(
         return if (prepared) player?.getCurrentPosition() else null
     }
 
-    fun isActuallyPlaying(): Boolean {
-        return playing && prepared && player?.isActuallyPlaying() == true
-    }
-
     val applicationContext: Context
         get() = ref.getApplicationContext()
 
@@ -207,7 +203,6 @@ class WrappedPlayer internal constructor(
                 initPlayer()
             } else if (prepared) {
                 currentPlayer.start()
-                ref.handleIsPlaying()
             }
         }
     }
@@ -277,7 +272,6 @@ class WrappedPlayer internal constructor(
         ref.handleDuration(this)
         if (playing) {
             player?.start()
-            ref.handleIsPlaying()
         }
         if (shouldSeekTo >= 0 && player?.isLiveStream() != true) {
             player?.seekTo(shouldSeekTo)

--- a/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
@@ -408,12 +408,6 @@ class AudioPlayersStreamHandler: NSObject, FlutterStreamHandler {
     }
   }
 
-  func onCurrentPosition(millis: Int) {
-    if let eventSink = self.sink {
-      eventSink(["event": "audio.onCurrentPosition", "value": millis] as [String: Any])
-    }
-  }
-
   func onDuration(millis: Int) {
     if let eventSink = self.sink {
       eventSink(["event": "audio.onDuration", "value": millis] as [String: Any])

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -18,7 +18,6 @@ class WrappedMediaPlayer {
   private var volume: Double
   private var url: String?
 
-  private var positionObserver: TimeObserver!
   private var completionObserver: TimeObserver?
   private var playerItemStatusObservation: NSKeyValueObservation?
 
@@ -42,8 +41,6 @@ class WrappedMediaPlayer {
     self.volume = volume
     self.looping = looping
     self.url = url
-
-    self.setUpPositionObserver(player)
   }
 
   func setSourceUrl(
@@ -152,7 +149,6 @@ class WrappedMediaPlayer {
 
   func dispose(completer: Completer? = nil) {
     release {
-      NotificationCenter.default.removeObserver(self.positionObserver.observer)
       completer?()
     }
   }
@@ -197,15 +193,6 @@ class WrappedMediaPlayer {
         break
       }
     }
-  }
-
-  private func setUpPositionObserver(_ player: AVPlayer) {
-    let interval = toCMTime(millis: 200)
-    let observer = player.addPeriodicTimeObserver(forInterval: interval, queue: nil) {
-      [weak self] time in
-      self?.onTimeInterval(time: time)
-    }
-    self.positionObserver = TimeObserver(player: player, observer: observer)
   }
 
   private func setUpSoundCompletedObserver(_ player: AVPlayer, _ playerItem: AVPlayerItem) {
@@ -262,10 +249,5 @@ class WrappedMediaPlayer {
 
     reference.controlAudioSession()
     eventHandler.onComplete()
-  }
-
-  private func onTimeInterval(time: CMTime) {
-    let millis = fromCMTime(time: time)
-    eventHandler.onCurrentPosition(millis: millis)
   }
 }

--- a/packages/audioplayers_linux/linux/audio_player.h
+++ b/packages/audioplayers_linux/linux/audio_player.h
@@ -78,7 +78,6 @@ class AudioPlayer {
   bool _isLooping = false;
   bool _isSeekCompleted = true;
   double _playbackRate = 1.0;
-  guint _refreshId;
 
   std::string _url{};
   std::string _playerId;
@@ -92,8 +91,6 @@ class AudioPlayer {
                                GstMessage* message,
                                AudioPlayer* data);
 
-  static gboolean OnRefresh(AudioPlayer* data);
-
   void SetPlayback(int64_t seekTo, double rate);
 
   void OnMediaError(GError* error, gchar* debug);
@@ -101,8 +98,6 @@ class AudioPlayer {
   void OnMediaStateChange(GstObject* src,
                           GstState* old_state,
                           GstState* new_state);
-
-  void OnPositionUpdate();
 
   void OnDurationUpdate();
 

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_event.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_event.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 
 enum AudioEventType {
   log,
-  position,
   duration,
   seekComplete,
   complete,
@@ -18,7 +17,6 @@ class AudioEvent {
   const AudioEvent({
     required this.eventType,
     this.duration,
-    this.position,
     this.logMessage,
     this.isPrepared,
   });
@@ -28,9 +26,6 @@ class AudioEvent {
 
   /// Duration of the audio.
   final Duration? duration;
-
-  /// Position of the audio.
-  final Duration? position;
 
   /// Log message in the player scope.
   final String? logMessage;
@@ -45,7 +40,6 @@ class AudioEvent {
             runtimeType == other.runtimeType &&
             eventType == other.eventType &&
             duration == other.duration &&
-            position == other.position &&
             logMessage == other.logMessage &&
             isPrepared == other.isPrepared;
   }
@@ -54,7 +48,6 @@ class AudioEvent {
   int get hashCode => Object.hash(
         eventType,
         duration,
-        position,
         logMessage,
         isPrepared,
       );
@@ -64,7 +57,6 @@ class AudioEvent {
     return 'AudioEvent('
         'eventType: $eventType, '
         'duration: $duration, '
-        'position: $position, '
         'logMessage: $logMessage, '
         'isPrepared: $isPrepared'
         ')';

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
@@ -242,14 +242,6 @@ mixin EventChannelAudioplayersPlatform
                   ? Duration(milliseconds: millis)
                   : Duration.zero,
             );
-          case 'audio.onCurrentPosition':
-            final millis = map.getInt('value');
-            return AudioEvent(
-              eventType: AudioEventType.position,
-              position: millis != null
-                  ? Duration(milliseconds: millis)
-                  : Duration.zero,
-            );
           case 'audio.onComplete':
             return const AudioEvent(eventType: AudioEventType.complete);
           case 'audio.onSeekComplete':

--- a/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
@@ -109,10 +109,6 @@ void main() {
             duration: Duration(milliseconds: 98765),
           ),
           const AudioEvent(
-            eventType: AudioEventType.position,
-            position: Duration(milliseconds: 8765),
-          ),
-          const AudioEvent(
             eventType: AudioEventType.log,
             logMessage: 'someLogMessage',
           ),
@@ -129,10 +125,6 @@ void main() {
         <String, dynamic>{
           'event': 'audio.onDuration',
           'value': 98765,
-        },
-        <String, dynamic>{
-          'event': 'audio.onCurrentPosition',
-          'value': 8765,
         },
         <String, dynamic>{
           'event': 'audio.onLog',

--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -19,7 +19,6 @@ class WrappedPlayer {
 
   AudioElement? player;
   StereoPannerNode? _stereoPanner;
-  StreamSubscription? _playerTimeUpdateSubscription;
   StreamSubscription? _playerEndedSubscription;
   StreamSubscription? _playerLoadedDataSubscription;
   StreamSubscription? _playerPlaySubscription;
@@ -117,17 +116,6 @@ class WrappedPlayer {
       },
       onError: eventStreamController.addError,
     );
-    _playerTimeUpdateSubscription = p.onTimeUpdate.listen(
-      (_) {
-        eventStreamController.add(
-          AudioEvent(
-            eventType: AudioEventType.position,
-            position: p.currentTime.fromSecondsToDuration(),
-          ),
-        );
-      },
-      onError: eventStreamController.addError,
-    );
     _playerSeekedSubscription = p.onSeeked.listen(
       (_) {
         eventStreamController.add(
@@ -188,8 +176,6 @@ class WrappedPlayer {
 
     _playerLoadedDataSubscription?.cancel();
     _playerLoadedDataSubscription = null;
-    _playerTimeUpdateSubscription?.cancel();
-    _playerTimeUpdateSubscription = null;
     _playerEndedSubscription?.cancel();
     _playerEndedSubscription = null;
     _playerSeekedSubscription?.cancel();

--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.cpp
@@ -35,20 +35,17 @@ class MediaEngineCallbackHelper
       MediaEngineWrapper::ErrorCB errorCB,
       MediaEngineWrapper::BufferingStateChangeCB bufferingStateChangeCB,
       std::function<void()> playbackEndedCB,
-      std::function<void()> timeUpdateCB,
       std::function<void()> seekCompletedCB)
       : m_onLoadedCB(onLoadedCB),
         m_errorCB(errorCB),
         m_bufferingStateChangeCB(bufferingStateChangeCB),
         m_playbackEndedCB(playbackEndedCB),
-        m_timeUpdateCB(timeUpdateCB),
         m_seekCompletedCB(seekCompletedCB) {
     // Ensure that callbacks are valid
     THROW_HR_IF(E_INVALIDARG, !m_onLoadedCB);
     THROW_HR_IF(E_INVALIDARG, !m_errorCB);
     THROW_HR_IF(E_INVALIDARG, !m_bufferingStateChangeCB);
     THROW_HR_IF(E_INVALIDARG, !m_playbackEndedCB);
-    THROW_HR_IF(E_INVALIDARG, !m_timeUpdateCB);
     THROW_HR_IF(E_INVALIDARG, !m_seekCompletedCB);
   }
   virtual ~MediaEngineCallbackHelper() = default;
@@ -60,7 +57,6 @@ class MediaEngineCallbackHelper
     m_errorCB = nullptr;
     m_bufferingStateChangeCB = nullptr;
     m_playbackEndedCB = nullptr;
-    m_timeUpdateCB = nullptr;
     m_seekCompletedCB = nullptr;
   }
 
@@ -89,9 +85,6 @@ class MediaEngineCallbackHelper
       case MF_MEDIA_ENGINE_EVENT_ENDED:
         m_playbackEndedCB();
         break;
-      case MF_MEDIA_ENGINE_EVENT_TIMEUPDATE:
-        m_timeUpdateCB();
-        break;
       case MF_MEDIA_ENGINE_EVENT_SEEKED:
         m_seekCompletedCB();
         break;
@@ -109,7 +102,6 @@ class MediaEngineCallbackHelper
   MediaEngineWrapper::ErrorCB m_errorCB;
   MediaEngineWrapper::BufferingStateChangeCB m_bufferingStateChangeCB;
   std::function<void()> m_playbackEndedCB;
-  std::function<void()> m_timeUpdateCB;
   std::function<void()> m_seekCompletedCB;
   bool m_detached = false;
 };
@@ -292,8 +284,7 @@ void MediaEngineWrapper::CreateMediaEngine() {
       [&]() { this->OnLoaded(); },
       [&](MF_MEDIA_ENGINE_ERR error, HRESULT hr) { this->OnError(error, hr); },
       [&](BufferingState state) { this->OnBufferingStateChange(state); },
-      [&]() { this->OnPlaybackEnded(); }, [&]() { this->OnTimeUpdate(); },
-      [&]() { this->OnSeekCompleted(); });
+      [&]() { this->OnPlaybackEnded(); }, [&]() { this->OnSeekCompleted(); });
   THROW_IF_FAILED(creationAttributes->SetUnknown(MF_MEDIA_ENGINE_CALLBACK,
                                                  m_callbackHelper.get()));
   THROW_IF_FAILED(
@@ -357,12 +348,6 @@ void MediaEngineWrapper::OnBufferingStateChange(BufferingState state) {
 void MediaEngineWrapper::OnPlaybackEnded() {
   if (m_playbackEndedCB) {
     m_playbackEndedCB();
-  }
-}
-
-void MediaEngineWrapper::OnTimeUpdate() {
-  if (m_timeUpdateCB) {
-    m_timeUpdateCB();
   }
 }
 

--- a/packages/audioplayers_windows/windows/MediaEngineWrapper.h
+++ b/packages/audioplayers_windows/windows/MediaEngineWrapper.h
@@ -23,13 +23,11 @@ class MediaEngineWrapper
                      ErrorCB errorCB,
                      BufferingStateChangeCB bufferingStateChangeCB,
                      std::function<void()> playbackEndedCB,
-                     std::function<void()> timeUpdateCB,
                      std::function<void()> seekCompletedCB)
       : m_initializedCB(initializedCB),
         m_errorCB(errorCB),
         m_bufferingStateChangeCB(bufferingStateChangeCB),
         m_playbackEndedCB(playbackEndedCB),
-        m_timeUpdateCB(timeUpdateCB),
         m_seekCompletedCB(seekCompletedCB) {}
   ~MediaEngineWrapper() {}
 
@@ -69,7 +67,6 @@ class MediaEngineWrapper
   ErrorCB m_errorCB;
   BufferingStateChangeCB m_bufferingStateChangeCB;
   std::function<void()> m_playbackEndedCB;
-  std::function<void()> m_timeUpdateCB;
   std::function<void()> m_seekCompletedCB;
   MFPlatformRef m_platformRef;
   winrt::com_ptr<IMFMediaEngine> m_mediaEngine;
@@ -80,7 +77,6 @@ class MediaEngineWrapper
   void OnError(MF_MEDIA_ENGINE_ERR error, HRESULT hr);
   void OnBufferingStateChange(BufferingState state);
   void OnPlaybackEnded();
-  void OnTimeUpdate();
   void OnSeekCompleted();
 };
 

--- a/packages/audioplayers_windows/windows/audio_player.h
+++ b/packages/audioplayers_windows/windows/audio_player.h
@@ -108,8 +108,6 @@ class AudioPlayer {
 
   void OnDurationUpdate();
 
-  void OnTimeUpdate();
-
   void OnSeekCompleted();
 
   void OnPrepared(bool isPrepared);


### PR DESCRIPTION
# Description

- Make the position stream updates configurable via `PositionUpdater`:
  - By default the position stream is updated on every new frame with help of `FramePositionUpdater`.
  - If setting the `AudioPlayer.positionUpdater` to `TimerPositionUpdater` , the position stream is updated in the according interval.
- The execution on the separate IO thread on Android was moved to the relevant code part in `SoundPoolPlayer`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

### Migration instructions

Removed in `audioplayers_platform_interface`:
```
AudioEventType.position
AudioEvent.position
```

## Related Issues

Closes #349
Closes #1525

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
