### PR TITLE
fix: source field is updated before `player.setSource()` call

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -27,7 +27,6 @@ class WrappedPlayer internal constructor(
     var source: Source? = null
         set(value) {
             if (field != value) {
-                field = value
                 if (value != null) {
                     val player = getOrCreatePlayer()
                     player.setSource(value)
@@ -38,6 +37,7 @@ class WrappedPlayer internal constructor(
                     playing = false
                     player?.release()
                 }
+                field = value
             } else {
                 ref.handlePrepared(this, true)
             }


### PR DESCRIPTION
# Description

Fix issue where source field is updated before player.setSource calls release(), which should affect previous source, not the new source.

This is fixed by moving the `field = value` line to after `player.setSource(value)` is called.

Details for the problematic call path:

1. `player.setSource(value)`
2. `SoundPoolPlayer.setSource`
3. `UrlSource.setForSoundPool`
4. `SoundPool.setUrlSource`
5. `SoundPoolPlayer.release()` (conditioned on `if soundId != null`)

`SoundPoolPlayer.release()` is called to free up the previous sound, and it does this based on the values of `this.soundId` and `this.urlSource`. These are supposed to be from the PREVIOUS sound (the one to be unloaded), not the CURRENT sound (the one to be loaded).

During the call to `release()` from `setUrlSource`, the `soundId` is correctly the previous version, but because the `field = value` line occurs BEFORE the call to `player.setSource`, the `this.urlSource` is NOT the previous version, it's the current version that's supposed to be loaded.

Ultimately because the `soundId` and `urlSource` don't match, this causes the synchronized update lines in `release()` to corrupt the `urlToPlayers` / `soundIdToPlayer` structures because the sound IDs and source IDs don't match.

I hope that explanation is reasonably clear. I checked the various other codepaths around here to see if having a later update of the `source` field would cause any problems, and I couldn't find any, but let me know if you can think of some way this ordering change would be bad.

I made the following reproduction to show the problem. Before this change, it results in playing incorrect sounds. With this particular setup, it plays the *same* sound two times, but it is expected to play two *different* sounds. After the change, it plays the two different sounds correctly as different sounds.

There are many other repros possible since there is some weird corruption of data structures happening, but this one is reliable for me on a Pixel 3a emulator.

```
  void soundTest(BuildContext context) async {
    var file1 = "notification_decorative-02.wav";
    var file2 = "hero_simple-celebration-03.wav";

    var player = AudioPlayer()
      ..setPlayerMode(PlayerMode.lowLatency)
      ..setReleaseMode(ReleaseMode.stop);

    await player.stop();
    await player.play(AssetSource(file1));
    await Future.delayed(Duration(milliseconds: 50), () {});
    await player.stop();
    await player.play(AssetSource(file2));
    await player.stop();

    player = AudioPlayer()
      ..setPlayerMode(PlayerMode.lowLatency)
      ..setReleaseMode(ReleaseMode.stop);

    await Future.delayed(Duration(seconds: 1), () {});

    await player.stop();
    await player.play(AssetSource(file1));

    await Future.delayed(Duration(seconds: 1), () {});

    await player.stop();
    await player.play(AssetSource(file2));
  }
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
