### PR TITLE
fix: Avoid encoding already encoded URI (closes #1669)

### DIFF
--- a/packages/audioplayers/lib/src/uri_ext.dart
+++ b/packages/audioplayers/lib/src/uri_ext.dart
@@ -1,10 +1,12 @@
 extension UriCoder on Uri {
   static String encodeOnce(String uri) {
-    var tmpUri = uri;
     try {
-      // Try decoding first to avoid encoding twice:
-      tmpUri = Uri.decodeFull(tmpUri);
+      // If decoded differs, the uri was already encoded.
+      final decodedUri = Uri.decodeFull(uri);
+      if (decodedUri != uri) {
+        return uri;
+      }
     } on ArgumentError catch (_) {}
-    return Uri.encodeFull(tmpUri);
+    return Uri.encodeFull(uri);
   }
 }

--- a/packages/audioplayers/test/uri_coder_test.dart
+++ b/packages/audioplayers/test/uri_coder_test.dart
@@ -1,0 +1,41 @@
+import 'package:audioplayers/src/uri_ext.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('UriCoder', () {
+    test(
+      'Encode Special Character',
+      () {
+        const uri = '/coins_non_ascii_и.wav';
+        final encoded = UriCoder.encodeOnce(uri);
+        expect(encoded, '/coins_non_ascii_%D0%B8.wav');
+      },
+    );
+    test(
+      'Encode Space',
+      () {
+        const uri = '/coins .wav';
+        final encoded = UriCoder.encodeOnce(uri);
+        expect(encoded, '/coins%20.wav');
+      },
+    );
+    test(
+      'Already encoded Character',
+      () {
+        const uri = 'https://myurl/audio%2F_music.mp4?alt=media&token=abc';
+        final encoded = UriCoder.encodeOnce(uri);
+        expect(encoded, uri);
+      },
+    );
+    test(
+      'Encoded and decoded are the same',
+      () {
+        const uri = 'https://myurl/audio';
+        final encoded = UriCoder.encodeOnce(uri);
+        expect(encoded, uri);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Description

Fixes #1669

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
