### PR TITLE
Fix #1597 : source set before seeking

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -187,6 +187,9 @@ class AudioPlayer {
     Duration? position,
     PlayerMode? mode,
   }) async {
+
+    await setSource(source);
+
     if (mode != null) {
       await setPlayerMode(mode);
     }
@@ -202,7 +205,7 @@ class AudioPlayer {
     if (position != null) {
       await seek(position);
     }
-    await setSource(source);
+
     await resume();
   }
 


### PR DESCRIPTION
# Description

This PR is fixing the bug in which in web while initialising the play with duration specified, there was no seek happening, which means that it starts from the beginning itself. setting the source before calling seek in play() function, instead of setting it afterwards solves the issue, bec the AudioElement instance _player in wrappedPlayer class should be initailised before seeking.

## Checklist


- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[[issue database]: https://github.com/bluefireteam/audioplayers/issues/1597
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
