### PR TITLE
fix: Seek not applied in `play` method

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -187,9 +187,6 @@ class AudioPlayer {
     Duration? position,
     PlayerMode? mode,
   }) async {
-
-
-
     if (mode != null) {
       await setPlayerMode(mode);
     }

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -187,6 +187,9 @@ class AudioPlayer {
     Duration? position,
     PlayerMode? mode,
   }) async {
+
+    await setSource(source);
+
     if (mode != null) {
       await setPlayerMode(mode);
     }
@@ -202,7 +205,7 @@ class AudioPlayer {
     if (position != null) {
       await seek(position);
     }
-    await setSource(source);
+
     await resume();
   }
 

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -188,7 +188,7 @@ class AudioPlayer {
     PlayerMode? mode,
   }) async {
 
-    await setSource(source);
+
 
     if (mode != null) {
       await setPlayerMode(mode);
@@ -202,6 +202,8 @@ class AudioPlayer {
     if (ctx != null) {
       await setAudioContext(ctx);
     }
+
+    await setSource(source);
     if (position != null) {
       await seek(position);
     }


### PR DESCRIPTION
# Description

This PR is fixing the bug in which in web while initialising the play with duration specified, there was no seek happening, which means that it starts from the beginning itself. setting the source before calling seek in play() function, instead of setting it afterwards solves the issue, bec the AudioElement instance _player in wrappedPlayer class should be initailised before seeking.

## Checklist


- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1597

<!-- Links -->
[issue database]: https://github.com/https://github.com/bluefireteam/audioplayers/issues/1597
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
