### PR TITLE
fix: Race condition when playing/pausing audio

### DIFF
--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -311,6 +311,23 @@ void main() async {
     );
   });
 
+  testWidgets('Race condition on play and pause (#1687)',
+      (WidgetTester tester) async {
+    final player = AudioPlayer();
+
+    await tester.pumpLinux();
+    final futurePlay = player.play(mp3Url1TestData.source);
+    final futurePause = player.pause();
+
+    await futurePlay;
+    await futurePause;
+
+    expect(player.state, PlayerState.paused);
+
+    await tester.pumpLinux();
+    await player.dispose();
+  });
+
   group(
     'Android only:',
     () {

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -317,7 +317,14 @@ void main() async {
 
     await tester.pumpLinux();
     final futurePlay = player.play(mp3Url1TestData.source);
+
+    // Player is still in `stopped` state as it isn't playing yet.
+    expect(player.state, PlayerState.stopped);
+    expect(player.desiredState, PlayerState.playing);
+
+    // Execute `pause` before `play` has finished.
     final futurePause = player.pause();
+    expect(player.desiredState, PlayerState.paused);
 
     await futurePlay;
     await futurePause;

--- a/packages/audioplayers/example/windows/flutter/CMakeLists.txt
+++ b/packages/audioplayers/example/windows/flutter/CMakeLists.txt
@@ -9,6 +9,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -91,7 +96,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/audioplayers/example/windows/flutter/CMakeLists.txt
+++ b/packages/audioplayers/example/windows/flutter/CMakeLists.txt
@@ -9,11 +9,6 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
-# Set fallback configurations for older versions of the flutter tool.
-if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
-  set(FLUTTER_TARGET_PLATFORM "windows-x64")
-endif()
-
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -96,7 +91,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
+      windows-x64 $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -57,6 +57,8 @@ class AudioPlayer {
 
   PlayerState _playerState = PlayerState.stopped;
 
+  PlayerState _desiredState = PlayerState.stopped;
+
   PlayerState get state => _playerState;
 
   set state(PlayerState state) {
@@ -66,7 +68,7 @@ class AudioPlayer {
     if (!_playerStateController.isClosed) {
       _playerStateController.add(state);
     }
-    _playerState = state;
+    _playerState = _desiredState = state;
   }
 
   PositionUpdater? _positionUpdater;
@@ -179,6 +181,10 @@ class AudioPlayer {
     }
   }
 
+  /// Play an audio [source].
+  ///
+  /// To reduce preparation latency, instead consider calling [setSource]
+  /// beforehand and then [resume] separately.
   Future<void> play(
     Source source, {
     double? volume,
@@ -187,6 +193,7 @@ class AudioPlayer {
     Duration? position,
     PlayerMode? mode,
   }) async {
+    _desiredState = PlayerState.playing;
     if (mode != null) {
       await setPlayerMode(mode);
     }
@@ -205,7 +212,7 @@ class AudioPlayer {
       await seek(position);
     }
 
-    await resume();
+    await _resume();
   }
 
   Future<void> setAudioContext(AudioContext ctx) async {
@@ -224,10 +231,17 @@ class AudioPlayer {
   /// If you call [resume] later, the audio will resume from the point that it
   /// has been paused.
   Future<void> pause() async {
+    _desiredState = PlayerState.paused;
+    await _pause();
+  }
+
+  Future<void> _pause() async {
     await creatingCompleter.future;
-    await _platform.pause(playerId);
-    state = PlayerState.paused;
-    await _positionUpdater?.stopAndUpdate();
+    if (_desiredState == PlayerState.paused) {
+      await _platform.pause(playerId);
+      state = PlayerState.paused;
+      await _positionUpdater?.stopAndUpdate();
+    }
   }
 
   /// Stops the audio that is currently playing.
@@ -235,18 +249,32 @@ class AudioPlayer {
   /// The position is going to be reset and you will no longer be able to resume
   /// from the last point.
   Future<void> stop() async {
+    _desiredState = PlayerState.stopped;
+    await _stop();
+  }
+
+  Future<void> _stop() async {
     await creatingCompleter.future;
-    await _platform.stop(playerId);
-    state = PlayerState.stopped;
-    await _positionUpdater?.stopAndUpdate();
+    if (_desiredState == PlayerState.stopped) {
+      await _platform.stop(playerId);
+      state = PlayerState.stopped;
+      await _positionUpdater?.stopAndUpdate();
+    }
   }
 
   /// Resumes the audio that has been paused or stopped.
   Future<void> resume() async {
+    _desiredState = PlayerState.playing;
+    await _resume();
+  }
+
+  Future<void> _resume() async {
     await creatingCompleter.future;
-    await _platform.resume(playerId);
-    state = PlayerState.playing;
-    _positionUpdater?.start();
+    if (_desiredState == PlayerState.playing) {
+      await _platform.resume(playerId);
+      state = PlayerState.playing;
+      _positionUpdater?.start();
+    }
   }
 
   /// Releases the resources associated with this media player.
@@ -256,7 +284,7 @@ class AudioPlayer {
   Future<void> release() async {
     await stop();
     await _platform.release(playerId);
-    state = PlayerState.stopped;
+    // Stop state already set in stop()
     _source = null;
   }
 
@@ -428,6 +456,7 @@ class AudioPlayer {
     // First stop and release all native resources.
     await release();
 
+    _desiredState = PlayerState.disposed;
     state = PlayerState.disposed;
 
     final futures = <Future>[

--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -238,10 +238,6 @@ class AudioPlayer {
   /// has been paused.
   Future<void> pause() async {
     desiredState = PlayerState.paused;
-    await _pause();
-  }
-
-  Future<void> _pause() async {
     await creatingCompleter.future;
     if (desiredState == PlayerState.paused) {
       await _platform.pause(playerId);
@@ -256,10 +252,6 @@ class AudioPlayer {
   /// from the last point.
   Future<void> stop() async {
     desiredState = PlayerState.stopped;
-    await _stop();
-  }
-
-  Future<void> _stop() async {
     await creatingCompleter.future;
     if (desiredState == PlayerState.stopped) {
       await _platform.stop(playerId);
@@ -274,6 +266,7 @@ class AudioPlayer {
     await _resume();
   }
 
+  /// Resume without setting the desired state.
   Future<void> _resume() async {
     await creatingCompleter.future;
     if (desiredState == PlayerState.playing) {
@@ -462,8 +455,7 @@ class AudioPlayer {
     // First stop and release all native resources.
     await release();
 
-    desiredState = PlayerState.disposed;
-    state = PlayerState.disposed;
+    state = desiredState = PlayerState.disposed;
 
     final futures = <Future>[
       if (_positionUpdater != null) _positionUpdater!.dispose(),


### PR DESCRIPTION
# Description

Fixes #1687

Instead we could also set the state always at the beginning of each method, but this raises these problems:
- If the operation in the method throws an error, the state doesn't match the native players state
- The state doesn't reflect the current real world audio state, as it's maybe still preparing/buffering and not actually playing

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1687

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
