### PR TITLE
ci: Remove setup-cocoapods on macos builds

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -155,10 +155,6 @@ jobs:
           channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
-      - name: setup-cocoapods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          podfile-path: ./packages/audioplayers/example/macos/Podfile.lock
       - name: Example app - Build macOS
         working-directory: ./packages/audioplayers/example
         run: flutter build macos --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,11 +252,6 @@ jobs:
           channel: 'stable'
       - uses: bluefireteam/melos-action@main
 
-      - name: setup-cocoapods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          podfile-path: ./packages/audioplayers/example/macos/Podfile.lock
-
       - name: Run Flutter integration tests
         working-directory: ./packages/audioplayers/example
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031


### PR DESCRIPTION
# Description

Setup-cocoapods is used to install the according version before building. But this is not necessarily needed, as a higher installation should still be able to execute macos apps with pods lower than described in the podfile.lock.

The package setup-cocoapods action includes a [bug]( https://github.com/maxim-lobanov/setup-cocoapods/pull/28) which let fail the CI from time to time. Flutter Gallery also doesn't setup the [cocoapod executable](https://github.com/flutter/gallery/blob/main/.github/workflows/build.yml).

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
