### PR TITLE
fix: Wait for seek to complete

### DIFF
--- a/packages/audioplayers/example/example.md
+++ b/packages/audioplayers/example/example.md
@@ -217,10 +217,6 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   }
 
   Future<void> _play() async {
-    final position = _position;
-    if (position != null && position.inMilliseconds > 0) {
-      await player.seek(position);
-    }
     await player.resume();
     setState(() => _playerState = PlayerState.playing);
   }

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -129,6 +129,7 @@ void main() async {
           }
           await tester.pumpLinux();
           await player.dispose();
+          await tester.pumpLinux(); // Needed to receive last position event
           final positions = await futurePositions;
           printOnFailure('Positions: $positions');
           expect(positions, isNot(contains(null)));

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -129,7 +129,6 @@ void main() async {
           }
           await tester.pumpLinux();
           await player.dispose();
-          await tester.pumpLinux(); // Needed to receive last position event
           final positions = await futurePositions;
           printOnFailure('Positions: $positions');
           expect(positions, isNot(contains(null)));

--- a/packages/audioplayers/example/lib/components/player_widget.dart
+++ b/packages/audioplayers/example/lib/components/player_widget.dart
@@ -159,10 +159,6 @@ class _PlayerWidgetState extends State<PlayerWidget> {
   }
 
   Future<void> _play() async {
-    final position = _position;
-    if (position != null && position.inMilliseconds > 0) {
-      await player.seek(position);
-    }
     await player.resume();
     setState(() => _playerState = PlayerState.playing);
   }

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -412,15 +412,18 @@ void AudioPlayer::Pause() {
 }
 
 void AudioPlayer::Stop() {
-  Pause()
+  Pause();
   if (!_isInitialized) {
     return;
   }
   SetPosition(0);
-  // Block thread to wait for state, as it is not expected to be waited to "seek complete" event on the dart side.
+  // Block thread to wait for state, as it is not expected to be waited to
+  // "seek complete" event on the dart side.
   GstState playbinState;
   gst_element_get_state(playbin, &playbinState, NULL, GST_CLOCK_TIME_NONE);
-  this->OnLog((std::string("Stop finished with state: ") + std::to_string(playbinState)).c_str());
+  this->OnLog(
+      (std::string("Stop finished with state: ") + std::to_string(playbinState))
+          .c_str());
 }
 
 void AudioPlayer::Resume() {

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -419,11 +419,11 @@ void AudioPlayer::Stop() {
   SetPosition(0);
   // Block thread to wait for state, as it is not expected to be waited to
   // "seek complete" event on the dart side.
-  GstState playbinState;
-  gst_element_get_state(playbin, &playbinState, NULL, GST_CLOCK_TIME_NONE);
-  this->OnLog(
-      (std::string("Stop finished with state: ") + std::to_string(playbinState))
-          .c_str());
+  GstStateChangeReturn ret =
+      gst_element_get_state(playbin, NULL, NULL, GST_CLOCK_TIME_NONE);
+  if (ret == GST_STATE_CHANGE_FAILURE) {
+    throw "Unable to seek playback to '0' while stopping the player.";
+  }
 }
 
 void AudioPlayer::Resume() {

--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -256,8 +256,7 @@ void AudioPlayer::OnPlaybackEnded() {
   if (GetLooping()) {
     Play();
   } else {
-    Pause();
-    SetPosition(0);
+    Stop();
   }
 }
 
@@ -410,6 +409,18 @@ void AudioPlayer::Pause() {
   } else if (ret == GST_STATE_CHANGE_FAILURE) {
     throw "Unable to set the pipeline to GST_STATE_PAUSED.";
   }
+}
+
+void AudioPlayer::Stop() {
+  Pause()
+  if (!_isInitialized) {
+    return;
+  }
+  SetPosition(0);
+  // Block thread to wait for state, as it is not expected to be waited to "seek complete" event on the dart side.
+  GstState playbinState;
+  gst_element_get_state(playbin, &playbinState, NULL, GST_CLOCK_TIME_NONE);
+  this->OnLog((std::string("Stop finished with state: ") + std::to_string(playbinState)).c_str());
 }
 
 void AudioPlayer::Resume() {

--- a/packages/audioplayers_linux/linux/audio_player.h
+++ b/packages/audioplayers_linux/linux/audio_player.h
@@ -36,6 +36,8 @@ class AudioPlayer {
 
   void Pause();
 
+  void Stop();
+
   void Resume();
 
   void Dispose();

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -137,8 +137,7 @@ static void audioplayers_linux_plugin_handle_method_call(
     } else if (strcmp(method, "resume") == 0) {
       player->Resume();
     } else if (strcmp(method, "stop") == 0) {
-      player->Pause();
-      player->SetPosition(0);
+      player->Stop();
     } else if (strcmp(method, "release") == 0) {
       player->ReleaseMediaSource();
     } else if (strcmp(method, "seek") == 0) {


### PR DESCRIPTION
# Description

Wait for seek to finish by listening to the `AudioEventType.seekComplete` event.

- [ ] need to validate if the tests are passing multiple times after each other
- [x] test what the Playbin GstState is after seeking

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
