### PR TITLE
feat!: Extend `AudioContextConfig.duckAudio` to `AudioContextConfig.focus`

### DIFF
--- a/packages/audioplayers/example/lib/tabs/audio_context.dart
+++ b/packages/audioplayers/example/lib/tabs/audio_context.dart
@@ -123,11 +123,13 @@ class AudioContextTabState extends State<AudioContextTab>
             audioContextConfig.copy(route: v),
           ),
         ),
-        Cbx(
-          'Duck Audio',
-          value: audioContextConfig.duckAudio,
-          ({value}) => updateConfig(
-            audioContextConfig.copy(duckAudio: value),
+        LabeledDropDown<AudioContextConfigFocus>(
+          label: 'Audio Focus',
+          key: const Key('audioFocus'),
+          options: {for (final e in AudioContextConfigFocus.values) e: e.name},
+          selected: audioContextConfig.focus,
+          onChange: (v) => updateConfig(
+            audioContextConfig.copy(focus: v),
           ),
         ),
         Cbx(

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -133,6 +133,10 @@ class AudioContextConfig {
       '$invalidMsg `respectSilence` and `duckOthers`. $tip',
     );
     assert(
+      !(respectSilence && focus == AudioContextConfigFocus.mixWithOthers),
+      '$invalidMsg `respectSilence` and `mixWithOthers`. $tip',
+    );
+    assert(
       !(respectSilence && route == AudioContextConfigRoute.speaker),
       '$invalidMsg `respectSilence` and route `speaker`. $tip',
     );
@@ -194,5 +198,9 @@ enum AudioContextConfigFocus {
 
   /// An option that indicates whether audio from this session mixes with audio
   /// from active sessions in other audio apps.
+  ///
+  /// On Android, it will set the focus [AndroidAudioFocus.none].
+  ///
+  /// On iOS, it will set the focus [AVAudioSessionOptions.mixWithOthers].
   mixWithOthers,
 }

--- a/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
+++ b/packages/audioplayers_platform_interface/lib/src/api/audio_context_config.dart
@@ -158,17 +158,16 @@ enum AudioContextConfigRoute {
   /// earpiece, or a bluetooth device.
   system,
 
-  /// On Android, it will set [AndroidUsageType.voiceCommunication].
+  /// On Android, this will set the usageType
+  /// [AndroidUsageType.voiceCommunication].
   ///
-  /// On iOS, it will set [AVAudioSessionCategory.playAndRecord].
+  /// On iOS, this will set the category [AVAudioSessionCategory.playAndRecord].
   earpiece,
 
-  /// On Android, it will set [AudioContextAndroid.isSpeakerphoneOn].
+  /// On Android, this will set [AudioContextAndroid.isSpeakerphoneOn] to true.
   ///
-  /// On iOS, it will either:
-  /// * set the [AVAudioSessionOptions.defaultToSpeaker] option OR
-  /// * call `overrideOutputAudioPort(AVAudioSession.PortOverride.speaker)`
-  /// Note that, on iOS, this forces the category to be
+  /// On iOS, this will set the option [AVAudioSessionOptions.defaultToSpeaker].
+  /// Note that this forces the category to be
   /// [AVAudioSessionCategory.playAndRecord], and thus is forbidden when
   /// [AudioContextConfig.respectSilence] is set.
   speaker,
@@ -178,9 +177,9 @@ enum AudioContextConfigFocus {
   /// An option that expresses the fact that your application is
   /// now the sole source of audio that the user is listening to.
   ///
-  /// On Android, it will set the focus [AndroidAudioFocus.gain].
+  /// On Android, this will set the focus [AndroidAudioFocus.gain].
   ///
-  /// On iOS, it will not set any additional [AVAudioSessionOptions].
+  /// On iOS, this will not set any additional [AVAudioSessionOptions].
   gain,
 
   /// An option that reduces the volume of other audio sessions while audio from
@@ -189,18 +188,18 @@ enum AudioContextConfigFocus {
   /// On Android, this will make an Audio Focus request with
   /// [AndroidAudioFocus.gainTransientMayDuck] when your audio starts playing.
   ///
-  /// On iOS, this will set the option [AVAudioSessionOptions.duckOthers] option
-  /// (the option [AVAudioSessionOptions.mixWithOthers] is always set,
-  /// regardless of these flags). Note that, on iOS, this forces the category to
-  /// be [AVAudioSessionCategory.playAndRecord], and thus is forbidden when
+  /// On iOS, this will set the option [AVAudioSessionOptions.duckOthers]
+  /// (the option [AVAudioSessionOptions.mixWithOthers] is set implicitly).
+  /// Note that this forces the category to be
+  /// [AVAudioSessionCategory.playAndRecord], and thus is forbidden when
   /// [AudioContextConfig.respectSilence] is set.
   duckOthers,
 
   /// An option that indicates whether audio from this session mixes with audio
   /// from active sessions in other audio apps.
   ///
-  /// On Android, it will set the focus [AndroidAudioFocus.none].
+  /// On Android, this will set the focus [AndroidAudioFocus.none].
   ///
-  /// On iOS, it will set the focus [AVAudioSessionOptions.mixWithOthers].
+  /// On iOS, this will set the option [AVAudioSessionOptions.mixWithOthers].
   mixWithOthers,
 }

--- a/packages/audioplayers_platform_interface/test/audio_context_test.dart
+++ b/packages/audioplayers_platform_interface/test/audio_context_test.dart
@@ -32,15 +32,16 @@ void main() {
   test('Check AudioContextConfig assertions', () async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     const boolValues = {true, false};
+    const focusValues = AudioContextConfigFocus.values;
     const routeValues = AudioContextConfigRoute.values;
 
     final throwsAssertion = [];
-    for (final isDuckAudio in boolValues) {
+    for (final focus in focusValues) {
       for (final isRespectSilence in boolValues) {
         for (final isStayAwake in boolValues) {
           for (final route in routeValues) {
             final config = AudioContextConfig(
-              duckAudio: isDuckAudio,
+              focus: focus,
               respectSilence: isRespectSilence,
               stayAwake: isStayAwake,
               route: route,
@@ -69,6 +70,18 @@ void main() {
     expect(
       throwsAssertion,
       const [
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
         true,
         true,
         true,
@@ -81,11 +94,11 @@ void main() {
         false,
         false,
         false,
-        false,
-        false,
         true,
-        false,
-        false,
+        true,
+        true,
+        true,
+        true,
         true,
         false,
         false,


### PR DESCRIPTION
# Description

- Introduces `AudioContextConfigFocus.mixWithOthers` to unify `AVAudioSessionOptions.mixWithOthers` (iOS) and `AndroidAudioFocus.none` (Android)
- Replaces the option `AudioContextConfig.duckAudio = true` with `AudioContextConfig.focus = AudioContextConfigFocus.duckOthers`

Closes #1718

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

### Migration instructions

Before:
```dart
AudioContextConfig(
  duckAudio: true,
);
```

After:
```dart
AudioContextConfig(
  focus: AudioContextConfigFocus.duckOthers,
);
```

## Related Issues

Closes #1718

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
