### PR TITLE
fix: Use unique tmp location for each AudioCache

### DIFF
--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -7,6 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+const _uuid = Uuid();
 
 /// This class represents a cache for Local Assets to be played.
 ///
@@ -45,7 +48,14 @@ class AudioCache {
   /// crucial).
   String prefix;
 
-  AudioCache({this.prefix = 'assets/'});
+  /// An unique ID generated for this instance of [AudioCache].
+  ///
+  /// This is used to load a file into an unique location in the temporary
+  /// directory.
+  String? cacheId;
+
+  AudioCache({this.prefix = 'assets/', String? cacheId})
+      : cacheId = cacheId ?? _uuid.v4();
 
   /// Clears the cache for the file [fileName].
   ///
@@ -89,7 +99,7 @@ class AudioCache {
     final byteData = await loadAsset('$prefix$fileName');
 
     // create a temporary file on the device to be read by the native side
-    final file = fileSystem.file('${await getTempDir()}/$fileName');
+    final file = fileSystem.file('${await getTempDir()}/$cacheId/$fileName');
     await file.create(recursive: true);
     await file.writeAsBytes(byteData.buffer.asUint8List());
 

--- a/packages/audioplayers/test/audio_cache_test.dart
+++ b/packages/audioplayers/test/audio_cache_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 class FakeAudioCache extends AudioCache {
   List<String> called = [];
 
-  FakeAudioCache({super.prefix});
+  FakeAudioCache({super.prefix, super.cacheId});
 
   @override
   Future<Uri> fetchToMemory(String fileName) async {
@@ -18,7 +18,7 @@ class FakeAudioCache extends AudioCache {
 
   @override
   Future<ByteData> loadAsset(String path) async {
-    return ByteData.sublistView((utf8.encode(path)) as Uint8List);
+    return ByteData.sublistView(utf8.encode(path));
   }
 
   @override
@@ -54,6 +54,20 @@ void main() {
       expect(cache.loadedFiles.isNotEmpty, isTrue);
       await cache.clear('audio.mp3');
       expect(cache.loadedFiles, <String, Uri>{});
+    });
+
+    test('Use different location for two audio caches', () async {
+      const fileName = 'audio.mp3';
+      final cacheA = FakeAudioCache(cacheId: 'cache-path-A');
+      await cacheA.load(fileName);
+      expect(cacheA.loadedFiles[fileName]?.path, '//cache-path-A/audio.mp3');
+
+      final cacheB = FakeAudioCache(cacheId: 'cache-path-B');
+      await cacheB.load(fileName);
+      expect(cacheB.loadedFiles[fileName]?.path, '//cache-path-B/audio.mp3');
+
+      await cacheA.clearAll();
+      await cacheB.clearAll();
     });
   });
 }


### PR DESCRIPTION
# Description

There are conflicts on writing to the same location of the temporary file path, when loading assets. This should be differentiated anyways as two individual AudioCaches should not share the same cache location.

Closes #1424 

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1424

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
