### PR TITLE
fix(linux): Handle failures of OnMediaStateChange in OnMediaError

### DIFF
--- a/packages/audioplayers_linux/linux/audio_player.cc
+++ b/packages/audioplayers_linux/linux/audio_player.cc
@@ -144,7 +144,8 @@ void AudioPlayer::OnMediaError(GError* error, gchar* debug) {
                       ", Code: " + std::to_string(error->code) + ")";
     FlValue* details = fl_value_new_string(detailsStr.c_str());
     // https://gstreamer.freedesktop.org/documentation/gstreamer/gsterror.html#enumerations
-    if (error->domain == GST_STREAM_ERROR) {
+    if (error->domain == GST_STREAM_ERROR ||
+        error->domain == GST_RESOURCE_ERROR) {
       message =
           "Failed to set source. For troubleshooting, "
           "see: " STR_LINK_TROUBLESHOOTING;
@@ -185,17 +186,12 @@ void AudioPlayer::OnMediaStateChange(GstObject* src,
       GstStateChangeReturn ret =
           gst_element_set_state(playbin, GST_STATE_PAUSED);
       if (ret == GST_STATE_CHANGE_FAILURE) {
+        // Only use [OnLog] as error is handled via [OnMediaError].
         gchar const* errorDescription =
+            "OnMediaStateChange -> GST_STATE_CHANGE_FAILURE:"
             "Unable to set the pipeline from GST_STATE_READY to "
             "GST_STATE_PAUSED.";
-        if (this->_isInitialized) {
-          this->OnError("LinuxAudioError", errorDescription, nullptr, nullptr);
-        } else {
-          this->OnError("LinuxAudioError",
-                        "Failed to set source. For troubleshooting, "
-                        "see: " STR_LINK_TROUBLESHOOTING,
-                        fl_value_new_string(errorDescription), nullptr);
-        }
+        this->OnLog(errorDescription);
       }
       if (this->_isInitialized) {
         this->_isInitialized = false;


### PR DESCRIPTION
# Description

Failures which occured in OnMediaStateChange method, were also thrown in OnMediaError. So the error was propagated twice and therefore the tests fail from time to time. This ensures to correctly throw the error only once, but also log the state change failure.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

The tests should already cover this, but succeeded anyways. This should change after #1715. 

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1715

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
