### PR TITLE
fix(ios): 'audioProcessing' deprecated in iOS 10

### DIFF
--- a/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
+++ b/packages/audioplayers_darwin/ios/Classes/AudioContext.swift
@@ -68,8 +68,6 @@ struct AudioContext {
       return .record
     case "playAndRecord":
       return .playAndRecord
-    case "audioProcessing":
-      return .audioProcessing
     case "multiRoute":
       return .multiRoute
     default:


### PR DESCRIPTION
# Description

Fixes the warning `'audioProcessing' was deprecated in iOS 10.0: No longer supported`.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #1402
Fixes #1722

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
