### PR TITLE
ci: Set system date time after downloading virtual audio device

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,12 @@ jobs:
       - uses: bluefireteam/melos-action@main
       - name: Start audio server
         run: net start audiosrv
+      - name: Download virtual audio device
+        # Download has to be done before setting the system date time.
+        timeout-minutes: 1
+        run: |
+          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
+          Expand-Archive -Path Scream.zip -DestinationPath Scream
       - name: Disable time sync with Hyper-V & setting system date time (#1573)
         # TODO(gustl22): Remove workaround of setting the time when virtual audio device certificate is valid again (#1573)
         run: |
@@ -302,8 +308,6 @@ jobs:
       - name: Install virtual audio device
         timeout-minutes: 1
         run: |
-          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream.zip
-          Expand-Archive -Path Scream.zip -DestinationPath Scream
           Import-Certificate -FilePath Scream\Install\driver\x64\Scream.cat -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
           Scream\Install\helpers\devcon-x64.exe install Scream\Install\driver\x64\Scream.inf *Scream
       - name: Resetting system date time (#1573)


### PR DESCRIPTION
# Description

On executing the windows tests, a virtual audio device is needed, which can only be installed with a certificate valid to a specific date. Recently the tests failed, as the date time was set before downloading and therefore threw a `NotTimeValid` error. This fixes that by downloading the source first, setting the date time and then installing it.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Occured in #925

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
