### PR TITLE
feat: Allows switching external playback mode in iOS

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -47,6 +47,15 @@ class AudioPlayer {
 
   double get playbackRate => _playbackRate;
 
+  bool _allowsExternalPlayback = false;
+
+  /// A Boolean value that indicates whether the player allows switching
+  /// to external playback mode.
+  ///
+  /// Default is [_allowsExternalPlayback] and
+  /// switch by calling [setAllowsExternalPlayback]
+  bool get allowsExternalPlayback => _allowsExternalPlayback;
+
   /// Current mode of the audio player. Can be updated at any time, but is going
   /// to take effect only at the next time you play the audio.
   PlayerMode _mode = PlayerMode.mediaPlayer;
@@ -168,6 +177,7 @@ class AudioPlayer {
     positionUpdater = FramePositionUpdater(
       getPosition: getCurrentPosition,
     );
+    setAllowsExternalPlayback(_allowsExternalPlayback);
   }
 
   Future<void> _create() async {
@@ -228,6 +238,16 @@ class AudioPlayer {
     _mode = mode;
     await creatingCompleter.future;
     return _platform.setPlayerMode(playerId, mode);
+  }
+
+  /// Switching the external playback mode
+  ///
+  /// Available in OS 6.0+ | iPadOS 6.0+ | Mac Catalyst 13.1+ |
+  ///
+  /// macOS 10.11+ | tvOS 9.0+
+  Future<void> setAllowsExternalPlayback(bool allows) async {
+    _allowsExternalPlayback = allows;
+    return _platform.setAllowsExternalPlayback(playerId, allows);
   }
 
   /// Pauses the audio that is currently playing.

--- a/packages/audioplayers/test/fake_audioplayers_platform.dart
+++ b/packages/audioplayers/test/fake_audioplayers_platform.dart
@@ -163,4 +163,9 @@ class FakeAudioplayersPlatform extends AudioplayersPlatformInterface {
     calls.add(FakeCall(id: playerId, method: 'getEventStream'));
     return eventStreamControllers[playerId]!.stream;
   }
+
+  @override
+  Future<void> setAllowsExternalPlayback(String playerId, bool allows) async {
+    calls.add(FakeCall(id: playerId, method: 'setAllowsExternalPlayback'));
+  }
 }

--- a/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/SwiftAudioplayersDarwinPlugin.swift
@@ -265,6 +265,16 @@ public class SwiftAudioplayersDarwinPlugin: NSObject, FlutterPlugin {
       let currentPosition = player.getCurrentPosition()
       result(currentPosition)
       return
+    } else if method == "setAllowsExternalPlayback" {
+      guard let allows = args["allows"] as? Bool else {
+        result(
+          FlutterError(
+            code: "DarwinAudioError", message: "Error calling setAllowsExternalPlayback, allows cannot be null",
+            details: nil))
+        return
+      }
+
+      player.setAllowsExternalPlayback(allows: allows)
     } else if method == "setPlaybackRate" {
       guard let playbackRate = args["playbackRate"] as? Double else {
         result(

--- a/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
+++ b/packages/audioplayers_darwin/darwin/Classes/WrappedMediaPlayer.swift
@@ -6,6 +6,8 @@ private let defaultVolume: Double = 1.0
 
 private let defaultLooping: Bool = false
 
+private let defaultAllowsExternalPlayback : Bool = false;
+
 typealias Completer = () -> Void
 
 typealias CompleterError = (Error?) -> Void
@@ -119,6 +121,14 @@ class WrappedMediaPlayer {
       // Setting the rate causes the player to resume playing. So setting it only, when already playing.
       player.rate = Float(playbackRate)
     }
+  }
+
+  func setAllowsExternalPlayback(allows: Bool) {
+    if #available(iOS 10.0, macOS 10.12, *) {
+        player.allowsExternalPlayback = allows;
+    }else{
+        player.allowsExternalPlayback = defaultAllowsExternalPlayback;
+    }  
   }
 
   func seek(time: CMTime, completer: Completer? = nil) {

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
@@ -125,6 +125,15 @@ mixin MethodChannelAudioplayersPlatform
   }
 
   @override
+  Future<void> setAllowsExternalPlayback(String playerId, bool allows) {
+    return _call(
+      'setAllowsExternalPlayback',
+      playerId,
+      <String, dynamic>{'allows': allows},
+    );
+  }
+
+  @override
   Future<void> setReleaseMode(String playerId, ReleaseMode releaseMode) {
     return _call(
       'setReleaseMode',

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
@@ -88,6 +88,9 @@ abstract class MethodChannelAudioplayersPlatformInterface {
   /// Android SDK version should be 23 or higher
   Future<void> setPlaybackRate(String playerId, double playbackRate);
 
+  /// Switching the external playback mode
+  Future<void> setAllowsExternalPlayback(String playerId, bool allows);
+
   /// Configures the player to read the audio from a URL.
   ///
   /// The resources will start being fetched or buffered as soon as you call

--- a/packages/audioplayers_web/lib/audioplayers_web.dart
+++ b/packages/audioplayers_web/lib/audioplayers_web.dart
@@ -100,6 +100,11 @@ class WebAudioplayersPlatform extends AudioplayersPlatformInterface {
   }
 
   @override
+  Future<void> setAllowsExternalPlayback(String playerId, bool allows) async {
+    // no-op: web doesn't have external playback, it supports only iOS, macOS
+  }
+
+  @override
   Future<void> setReleaseMode(String playerId, ReleaseMode releaseMode) async {
     getPlayer(playerId).releaseMode = releaseMode;
   }


### PR DESCRIPTION
# Description

Here are the specific behaviors when streaming to an Apple TV or Mac:

**allowsExternalPlayback = true** (default, current behavior of the audioplayers package)
![226296874-3bf27f85-3eb2-4291-a5f0-4249e1a4ddd4](https://github.com/bluefireteam/audioplayers/assets/65641460/ee8c780a-540f-426f-bc12-2fdcce3851af)

<img width="1680" alt="226296902-6e1e1530-7c0f-4292-9f75-fc869a6ec499" src="https://github.com/bluefireteam/audioplayers/assets/65641460/a0dbecc7-4d5c-4f5a-a946-dea0cbc22514">


- Both devices show fullscreen playback controls.
- On Apple TV, playback can be controlled with the remote, including seeking.
- Both devices become unusable for other tasks as the player covers the screen.

**allowsExternalPlayback = false**

![226296959-3a74667c-0622-4a46-8b89-68a232bfc2b3](https://github.com/bluefireteam/audioplayers/assets/65641460/8a158e19-7aa3-4cc1-85bc-7a1a3ff4b976)

![226297191-b11edccd-e629-4c60-b676-27f9a2fa8bd6](https://github.com/bluefireteam/audioplayers/assets/65641460/f163eb07-9289-408d-92f2-bebfd240f6fa)


- Apple TV shows a notification briefly when a new media item starts playing.
- macOS adds playback controls to the menu.

Apple Podcasts and other iOS apps use the `allowsExternalPlayback = false` setting, suggesting this is the intended behavior for pure audio apps. However, the video-like behavior with `allowsExternalPlayback = true` may still be useful for some developers as it enables playback controls on the Apple TV, even if this use case is rare.

Therefore, the default value is set to `false`.


## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues
