### PR TITLE
fix: handle audio play when it is user pause action

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -114,6 +114,8 @@ class WrappedPlayer internal constructor(
 
     var playing = false
     var shouldSeekTo = -1
+    var playBack = false
+    var pausePlayback = false
 
     private val focusManager = FocusManager(this)
 
@@ -192,11 +194,13 @@ class WrappedPlayer internal constructor(
      * Playback handling methods
      */
     fun play() {
+        playBack = true
+        pausePlayback = false
         focusManager.maybeRequestAudioFocus(andThen = ::actuallyPlay)
     }
 
     private fun actuallyPlay() {
-        if (!playing && !released) {
+        if (!playing && !released && (!pausePlayback || playBack)) {
             val currentPlayer = player
             playing = true
             if (currentPlayer == null) {
@@ -209,6 +213,8 @@ class WrappedPlayer internal constructor(
 
     fun stop() {
         focusManager.handleStop()
+        pausePlayback = true
+        playBack = false
         if (released) {
             return
         }
@@ -230,6 +236,8 @@ class WrappedPlayer internal constructor(
     }
 
     fun release() {
+        pausePlayback = true
+        playBack = false
         focusManager.handleStop()
         if (released) {
             return
@@ -247,6 +255,8 @@ class WrappedPlayer internal constructor(
     fun pause() {
         if (playing) {
             playing = false
+            playBack = false
+            pausePlayback = true
             if (prepared) {
                 player?.pause()
             }


### PR DESCRIPTION
# Description
When audioplayers is in pause state, then don't resume after call interruption.

## Checklist
- [x ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [ x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [ x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues
Fixes #1688 

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
