### PR TITLE
fix: Avoid multiple audioFocusRequest instances for focus changes

### DIFF
--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
@@ -13,11 +13,10 @@ class FocusManager(
     private val context: AudioContextAndroid
         get() = player.context
 
-
     // Listen also for focus changes, e.g. if interrupt playing with a phone call and resume afterward.
     private var audioFocusRequest: AudioFocusRequest? = null
 
-    // Deprecated variant for listenfixing to focus changes
+    // Deprecated variant of listening to focus changes
     private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
 
     init {

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
@@ -8,7 +8,7 @@ import xyz.luan.audioplayers.AudioContextAndroid
 class FocusManager(
     private val player: WrappedPlayer,
     private val onGranted: () -> Unit,
-    private val onLoss: (isTransient: Boolean) -> Unit
+    private val onLoss: (isTransient: Boolean) -> Unit,
 ) {
     private val context: AudioContextAndroid
         get() = player.context
@@ -16,10 +16,10 @@ class FocusManager(
 
     // Listen also for focus changes, e.g. if interrupt playing with a phone call and resume afterward.
     private var audioFocusRequest: AudioFocusRequest? = null
-    
+
     // Deprecated variant for listenfixing to focus changes
     private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
-    
+
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             audioFocusRequest = AudioFocusRequest.Builder(context.audioFocus)

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/FocusManager.kt
@@ -3,29 +3,51 @@ package xyz.luan.audioplayers.player
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
-import androidx.annotation.RequiresApi
 import xyz.luan.audioplayers.AudioContextAndroid
 
 class FocusManager(
     private val player: WrappedPlayer,
+    private val onGranted: () -> Unit,
+    private val onLoss: (isTransient: Boolean) -> Unit
 ) {
-    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
-    private var audioFocusRequest: AudioFocusRequest? = null
-
     private val context: AudioContextAndroid
         get() = player.context
+
+
+    // Listen also for focus changes, e.g. if interrupt playing with a phone call and resume afterward.
+    private var audioFocusRequest: AudioFocusRequest? = null
+    
+    // Deprecated variant for listenfixing to focus changes
+    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
+    
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest = AudioFocusRequest.Builder(context.audioFocus)
+                .setAudioAttributes(context.buildAttributes())
+                .setOnAudioFocusChangeListener { handleFocusResult(it) }
+                .build()
+        } else {
+            audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { handleFocusResult(it) }
+        }
+    }
 
     private val audioManager: AudioManager
         get() = player.audioManager
 
-    fun maybeRequestAudioFocus(onGranted: () -> Unit, onLoss: (isTransient: Boolean) -> Unit) {
+    fun maybeRequestAudioFocus() {
         if (context.audioFocus == AudioManager.AUDIOFOCUS_NONE) {
             onGranted()
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            newRequestAudioFocus(onGranted, onLoss)
+            val result = audioManager.requestAudioFocus(audioFocusRequest!!)
+            handleFocusResult(result)
         } else {
             @Suppress("DEPRECATION")
-            oldRequestAudioFocus(onGranted, onLoss)
+            val result = audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                context.audioFocus,
+            )
+            handleFocusResult(result)
         }
     }
 
@@ -40,35 +62,7 @@ class FocusManager(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun newRequestAudioFocus(onGranted: () -> Unit, onLoss: (isTransient: Boolean) -> Unit) {
-        val audioFocus = context.audioFocus
-
-        // Listen also for focus changes, e.g. if interrupt playing with a phone call and resume afterward.
-        val audioFocusRequest = AudioFocusRequest.Builder(audioFocus)
-            .setAudioAttributes(context.buildAttributes())
-            .setOnAudioFocusChangeListener { handleFocusResult(it, onGranted, onLoss) }
-            .build()
-        this.audioFocusRequest = audioFocusRequest
-
-        val result = audioManager.requestAudioFocus(audioFocusRequest)
-        handleFocusResult(result, onGranted, onLoss)
-    }
-
-    @Deprecated("Use requestAudioFocus instead")
-    private fun oldRequestAudioFocus(onGranted: () -> Unit, onLoss: (isTransient: Boolean) -> Unit) {
-        val audioFocus = context.audioFocus
-        audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { handleFocusResult(it, onGranted, onLoss) }
-        @Suppress("DEPRECATION")
-        val result = audioManager.requestAudioFocus(
-            audioFocusChangeListener,
-            AudioManager.STREAM_MUSIC,
-            audioFocus,
-        )
-        handleFocusResult(result, onGranted, onLoss)
-    }
-
-    private fun handleFocusResult(result: Int, onGranted: () -> Unit, onLoss: (isTransient: Boolean) -> Unit) {
+    private fun handleFocusResult(result: Int) {
         when (result) {
             AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
                 onGranted()


### PR DESCRIPTION
# Description

Fixes https://github.com/bluefireteam/audioplayers/pull/1857#issuecomment-2574538819

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
