### PR TITLE
ci: Use path dependency for audioplayers_android_exo tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
           flutter-version: ${{ inputs.flutter_version }}
           channel: ${{ inputs.flutter_channel }}
       - name: Override endorsed plugin with audioplayers_android_exo
-        run: flutter pub add 'audioplayers_android_exo:{"path":"../../audioplayers_android_exo"}'
+        run: dart pub add "audioplayers_android_exo:{path: ../../audioplayers_android_exo}"
         working-directory: ./packages/audioplayers/example
       - uses: bluefireteam/melos-action@v3
       - name: Setup Android Emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
           flutter-version: ${{ inputs.flutter_version }}
           channel: ${{ inputs.flutter_channel }}
       - name: Override endorsed plugin with audioplayers_android_exo
-        run: dart pub add 'audioplayers_android_exo:{path: ../../audioplayers_android_exo}'
+        run: dart pub add "audioplayers_android_exo:{path:../../audioplayers_android_exo}"
         working-directory: ./packages/audioplayers/example
       - uses: bluefireteam/melos-action@v3
       - name: Setup Android Emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
           flutter-version: ${{ inputs.flutter_version }}
           channel: ${{ inputs.flutter_channel }}
       - name: Override endorsed plugin with audioplayers_android_exo
-        run: dart pub add "audioplayers_android_exo:{path: ../../audioplayers_android_exo}"
+        run: dart pub add 'audioplayers_android_exo:{path: ../../audioplayers_android_exo}'
         working-directory: ./packages/audioplayers/example
       - uses: bluefireteam/melos-action@v3
       - name: Setup Android Emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
           flutter-version: ${{ inputs.flutter_version }}
           channel: ${{ inputs.flutter_channel }}
       - name: Override endorsed plugin with audioplayers_android_exo
-        run: flutter pub add audioplayers_android_exo
+        run: flutter pub add 'audioplayers_android_exo:{"path":"../../audioplayers_android_exo"}'
         working-directory: ./packages/audioplayers/example
       - uses: bluefireteam/melos-action@v3
       - name: Setup Android Emulator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,8 @@ jobs:
           flutter-version: ${{ inputs.flutter_version }}
           channel: ${{ inputs.flutter_channel }}
       - name: Override endorsed plugin with audioplayers_android_exo
-        run: dart pub add "audioplayers_android_exo:{path:../../audioplayers_android_exo}"
+        run: |
+          dart pub add "audioplayers_android_exo:{path: ../../audioplayers_android_exo}"
         working-directory: ./packages/audioplayers/example
       - uses: bluefireteam/melos-action@v3
       - name: Setup Android Emulator


### PR DESCRIPTION
# Description

During publishing the package version dependencies are already raised to newer versions, which are not resolvable for `flutter pub add`. So we use path dependency. so common dependencies are in sync with melos relative dependencies.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

See build failure of #1909

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
