### PR TITLE
feat: Customizable preparation and seeking timeout

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -19,8 +19,8 @@ const _uuid = Uuid();
 /// hooks for handlers and callbacks.
 class AudioPlayer {
   static final global = GlobalAudioScope();
-  static const preparationTimeout = Duration(seconds: 30);
-  static const seekingTimeout = Duration(seconds: 30);
+  static Duration preparationTimeout = const Duration(seconds: 30);
+  static Duration seekingTimeout = const Duration(seconds: 30);
 
   final _platform = AudioplayersPlatformInterface.instance;
 


### PR DESCRIPTION
# Description

Added customizable timeout used for seeking and preparation of the player.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Closes #1920 
