### PR TITLE
fix: FileNotFoundException after application cache got cleared

### DIFF
--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -126,7 +126,9 @@ class AudioCache {
   ///
   /// Returns a [Uri] to access that file.
   Future<Uri> load(String fileName) async {
-    if (!loadedFiles.containsKey(fileName)) {
+    if (!loadedFiles.containsKey(fileName) ||
+        // the file can be removed from the cache, this can happen automatically when the storage is almost full
+        (!kIsWeb && !fileSystem.file(loadedFiles[fileName]!).existsSync())) {
       loadedFiles[fileName] = await fetchToMemory(fileName);
     }
     return loadedFiles[fileName]!;


### PR DESCRIPTION
# Description

When an android device is low on storage, it can happen that the OS clears the cache of the app. In that case we get a FileNotFoundException when running an audio file for the 2nd time.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

-  Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

- Fixes https://github.com/bluefireteam/audioplayers/issues/1778

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
