### PR TITLE
fix(windows): Refactor static globals to instance members

### DIFF
--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -61,9 +61,6 @@ class AudioplayersWindowsPlugin : public Plugin {
   // Map to keep player event channels alive
   std::map<std::string, std::unique_ptr<EventChannel<EncodableValue>>>
       playerEventChannels;
-  // Map to keep player event handlers alive
-  std::map<std::string, std::unique_ptr<EventStreamHandler<EncodableValue>>>
-      playerEventHandlers;
 
   // Called when a method is called on this plugin's channel from Dart.
   void HandleMethodCall(const MethodCall<EncodableValue>& method_call,
@@ -266,7 +263,6 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
     player->Dispose();
     audioPlayers.erase(playerId);
     playerEventChannels.erase(playerId);
-    playerEventHandlers.erase(playerId);
   } else {
     result->NotImplemented();
     return;


### PR DESCRIPTION
fix(windows): support multi-engine and fix crashes in multi-window environments

# Description

Previously, `AudioplayersWindowsPlugin` utilized `static inline` global variables for the `MethodChannel` and `EventStreamHandler`. In multi-window scenarios (e.g., using `desktop_multi_window`), where multiple Flutter Engines are initialized, these static pointers were overwritten by the most recently opened window. This caused the plugin state of previous windows to become corrupted, leading to crashes and inconsistent behavior.

This PR refactors the plugin to move these globals into instance members. This ensures:
- Each Engine instance maintains its own independent `MethodChannel` and `EventStreamHandler`.
- Plugin states are completely isolated across different windows.
- Memory safety is improved by preventing the overwriting of global static pointers.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality. (N/A for architectural refactor)
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Resolves crashes in multi-window/multi-engine environments on Windows.

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example