### PR TITLE
ci: Bump Melos to ^7.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
   sdk: ^3.6.0
 
 dev_dependencies:
-  melos: ^7.0.0-dev.8
+  melos: ^7.4.0
 
 melos:
   command:


### PR DESCRIPTION
Just bumps Melos to a stable version now when the min version the Dart SDK used with audioplayers is ^3.9.0.