### PR TITLE
fix(web): Use GainNode for volume control to fix Safari compatibility

### DIFF
--- a/packages/audioplayers_web/lib/wrapped_player.dart
+++ b/packages/audioplayers_web/lib/wrapped_player.dart
@@ -20,6 +20,7 @@ class WrappedPlayer {
   web.HTMLAudioElement? player;
   web.AudioContext? _audioContext;
   web.MediaElementAudioSourceNode? _sourceNode;
+  web.GainNode? _gainNode;
   web.StereoPannerNode? _stereoPanner;
   StreamSubscription? _playerEndedSubscription;
   StreamSubscription? _playerLoadedDataSubscription;
@@ -50,7 +51,7 @@ class WrappedPlayer {
 
   set volume(double volume) {
     _currentVolume = volume;
-    player?.volume = volume;
+    _gainNode?.gain.value = volume;
   }
 
   set balance(double balance) {
@@ -76,7 +77,6 @@ class WrappedPlayer {
     // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     p.crossOrigin = 'anonymous';
     p.loop = shouldLoop();
-    p.volume = _currentVolume;
     p.playbackRate = _currentPlaybackRate;
 
     _setupStreams(p);
@@ -86,8 +86,11 @@ class WrappedPlayer {
 
     final source = _audioContext!.createMediaElementSource(p);
     _sourceNode = source;
+    _gainNode = _audioContext!.createGain();
+    _gainNode!.gain.value = _currentVolume;
     _stereoPanner = _audioContext!.createStereoPanner();
-    source.connect(_stereoPanner!);
+    source.connect(_gainNode!);
+    _gainNode!.connect(_stereoPanner!);
     _stereoPanner?.connect(_audioContext!.destination);
 
     // Preload the source
@@ -181,6 +184,8 @@ class WrappedPlayer {
 
     _sourceNode?.disconnect();
     _sourceNode = null;
+    _gainNode?.disconnect();
+    _gainNode = null;
     // Release `AudioElement` correctly (#966)
     player?.src = '';
     player?.remove();


### PR DESCRIPTION
# Description

When an `HTMLAudioElement` is connected to the Web Audio API via `createMediaElementSource()`, Safari ignores the `HTMLMediaElement.volume` property — the audio is routed through the Web Audio API graph and Safari expects volume to be controlled within that graph.

Previously, volume was set directly on the `HTMLAudioElement.volume` property, which only worked on Chrome (Chrome honors `element.volume` even after connecting to Web Audio API).

This PR replaces `HTMLAudioElement.volume` with a `GainNode` inserted into the Web Audio API processing chain:

**Before:** `MediaElementSource → StereoPanner → Destination` (volume via `element.volume`)
**After:** `MediaElementSource → GainNode → StereoPanner → Destination` (volume via `gainNode.gain.value`)

This is the [standard pattern recommended by MDN](https://github.com/mdn/webaudio-examples/blob/main/audio-basics/index.html) for controlling volume in Web Audio API.

**How to reproduce:**
1. Open https://bluefireteam.github.io/audioplayers/ in Safari
2. Play any sound
3. Change the volume — nothing happens, volume stays the same
4. Open the same page in Chrome — volume control works correctly

**Why `GainNode` is the correct fix:**
- [MDN: GainNode — supported in all browsers](https://developer.mozilla.org/en-US/docs/Web/API/GainNode)

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example