### PR TITLE
fix: Always check if file exists when playing from cache

### DIFF
--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -130,7 +130,8 @@ class AudioCache {
 
     // Verify that the cached file still exists. It can be removed
     // by the system when the storage is almost full
-    // see https://developer.android.com/training/data-storage/app-specific#internal-remove-cache
+    // Android: https://developer.android.com/training/data-storage/app-specific#internal-remove-cache
+    // iOS: https://developer.apple.com/documentation/foundation/using-the-file-system-effectively#Store-short-lived-files
     if (!needsFetch && !await fileSystem.file(loadedFiles[fileName]).exists()) {
       needsFetch = true;
     }

--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -131,9 +131,7 @@ class AudioCache {
     // On Android, verify that the cached file still exists. It can be removed
     // by the system when the storage is almost full
     // see https://developer.android.com/training/data-storage/app-specific#internal-remove-cache
-    if (!needsFetch &&
-        defaultTargetPlatform == TargetPlatform.android &&
-        !await fileSystem.file(loadedFiles[fileName]).exists()) {
+    if (!needsFetch && !await fileSystem.file(loadedFiles[fileName]).exists()) {
       needsFetch = true;
     }
 

--- a/packages/audioplayers/lib/src/audio_cache.dart
+++ b/packages/audioplayers/lib/src/audio_cache.dart
@@ -128,7 +128,7 @@ class AudioCache {
   Future<Uri> load(String fileName) async {
     var needsFetch = !loadedFiles.containsKey(fileName);
 
-    // On Android, verify that the cached file still exists. It can be removed
+    // Verify that the cached file still exists. It can be removed
     // by the system when the storage is almost full
     // see https://developer.android.com/training/data-storage/app-specific#internal-remove-cache
     if (!needsFetch && !await fileSystem.file(loadedFiles[fileName]).exists()) {


### PR DESCRIPTION
# Description

The caching issue that was fixed on Android also exists on iOS. This PR removes the platform check so that the file existence is validated on all platforms.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [ ] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.