### PR TITLE
fix(audioplayers_android_exo): apply setVolume to mono audio sources

### DIFF
--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
@@ -135,8 +135,20 @@ class ExoPlayerWrapper(
 
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     override fun setVolume(leftVolume: Float, rightVolume: Float) {
+        // AdaptiveChannelMixingAudioProcessor looks up the matrix by the
+        // *source's* channel count at queueInput time. Register an entry for
+        // both mono (channelCount = 1) and stereo (channelCount = 2) inputs,
+        // otherwise mono sources fall through `matrixByInputChannelCount[1] == null`
+        // and play back at full volume regardless of the requested level.
         this.channelMixingAudioProcessor.putChannelMixingMatrix(
             ChannelMixingMatrix(2, 2, floatArrayOf(leftVolume, 0f, 0f, rightVolume)),
+        )
+        // For mono input, balance has no meaning — average left/right into a
+        // single scalar so callers that pass differing left/right volumes
+        // still produce a sensible perceived level.
+        val monoVolume = (leftVolume + rightVolume) / 2f
+        this.channelMixingAudioProcessor.putChannelMixingMatrix(
+            ChannelMixingMatrix(1, 1, floatArrayOf(monoVolume)),
         )
     }
 


### PR DESCRIPTION
# Description

Fixes #1986.

`ExoPlayerWrapper.setVolume` currently registers only a stereo `ChannelMixingMatrix(2, 2, ...)` on the underlying `AdaptiveChannelMixingAudioProcessor`. The processor's `queueInput` looks up the matrix by the *source's* `inputAudioFormat.channelCount` — so for **mono inputs** (`channelCount = 1`) the lookup returns `null`, the processor short-circuits to a passthrough, and `setVolume` becomes a silent no-op.

This regresses any app that uses `audioplayers_android_exo` in place of `audioplayers_android` and plays single-channel content (voiceovers, podcasts, meditation tracks, TTS output, low-bitrate streams, etc.). The bug is hard to notice in testing because most test audio happens to be stereo, where the existing code path works correctly.

## What this PR changes

- In `ExoPlayerWrapper.setVolume`, register a second `ChannelMixingMatrix(1, 1, ...)` alongside the existing stereo one, so the lookup also succeeds for `channelCount = 1` sources.
- The mono matrix uses the **average** of `leftVolume` and `rightVolume`, since balance has no meaning for single-channel input. Callers that pass equal left/right values (the overwhelming majority — including the `AudioPlayer.setVolume(double)` public API which calls `setVolume(volume, volume)` under the hood) get exactly that level applied. Callers that pass differing values get a sensible perceived level instead of being silently ignored.
- Stereo behaviour is unchanged.

## Code change

```kotlin
@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
override fun setVolume(leftVolume: Float, rightVolume: Float) {
    // AdaptiveChannelMixingAudioProcessor looks up the matrix by the
    // *source's* channel count at queueInput time. Register an entry for
    // both mono (channelCount = 1) and stereo (channelCount = 2) inputs,
    // otherwise mono sources fall through `matrixByInputChannelCount[1] == null`
    // and play back at full volume regardless of the requested level.
    this.channelMixingAudioProcessor.putChannelMixingMatrix(
        ChannelMixingMatrix(2, 2, floatArrayOf(leftVolume, 0f, 0f, rightVolume)),
    )
    // For mono input, balance has no meaning — average left/right into a
    // single scalar so callers that pass differing left/right volumes
    // still produce a sensible perceived level.
    val monoVolume = (leftVolume + rightVolume) / 2f
    this.channelMixingAudioProcessor.putChannelMixingMatrix(
        ChannelMixingMatrix(1, 1, floatArrayOf(monoVolume)),
    )
}
```

## Manual verification

Reproduced and validated on a real device (OnePlus 6T, Android 11, audioplayers 6.6.0, audioplayers_android_exo 0.1.3):

- Mono MP3 source + `player.setVolume(0.0)` → **before:** still full volume; **after:** muted
- Mono MP3 source + `player.setVolume(0.5)` → **before:** still full volume; **after:** half volume
- Stereo MP3 source + `player.setVolume(0.5)` → unchanged in both (works correctly)
- No regression on `setBalance` for stereo sources

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
      <!-- No existing unit-test scaffolding covers `ExoPlayerWrapper.setVolume`; happy to add one in this PR if the maintainers point me at the preferred test style (instrumented vs. JVM). The change was validated manually on device as described above. -->
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
      <!-- Inline Kotlin comments explain the rationale at the point of change. No public Dart API changed. -->
- [ ] I have updated/added relevant examples in [example].
      <!-- The bug is invisible in the existing example because the bundled sample sources are stereo. No example change needed for the fix to be exercised. -->

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
