### PR TITLE
ci: Disable macos tests as fails to foreground app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,7 +369,8 @@ jobs:
   macos:
     runs-on: macos-latest
     timeout-minutes: 30
-    if: inputs.enable_macos
+    # Temporary disable because of https://github.com/flutter/flutter/issues/176850
+    if: false && inputs.enable_macos
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2


### PR DESCRIPTION
# Description

Pipeline is currently timing out on GH with Image Macos 15.7.7.
As we also provide tests for Macos 14, we should temporarly disable the tests until a solution for https://github.com/flutter/flutter/issues/176850 is provided.
See example run: https://github.com/bluefireteam/audioplayers/actions/runs/26475948464/job/77961428758

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

See: https://github.com/flutter/flutter/issues/176850

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
