### PR TITLE
feat(android): Compatibility with Built-In Kotlin

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,8 @@ jobs:
   call-min-flutter-test:
     uses: ./.github/workflows/test.yml
     with:
-      flutter_version: '3.35.7'
+      # Currently the same as max supported version, to support AGP 9.
+      flutter_version: '3.44.0'
       fatal_warnings: false
       enable_android: ${{ github.event.pull_request.draft == false }}
       enable_web: ${{ github.event.pull_request.draft == false }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,12 @@ jobs:
     if: inputs.enable_android
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v5
+        with:
+          # Android SDK 36 needs JDK 21
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ inputs.flutter_version }}
@@ -256,6 +262,12 @@ jobs:
     if: inputs.enable_android
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v5
+        with:
+          # Android SDK 36 needs JDK 21
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ inputs.flutter_version }}

--- a/packages/audioplayers/example/.metadata
+++ b/packages/audioplayers/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "edada7c56edf4a183c1735310e123c7f923584f1"
+  revision: "559ffa3f75e7402d65a8def9c28389a9b2e6fe42"
   channel: "stable"
 
 project_type: app
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: edada7c56edf4a183c1735310e123c7f923584f1
-      base_revision: edada7c56edf4a183c1735310e123c7f923584f1
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: android
-      create_revision: edada7c56edf4a183c1735310e123c7f923584f1
-      base_revision: edada7c56edf4a183c1735310e123c7f923584f1
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: ios
       create_revision: edada7c56edf4a183c1735310e123c7f923584f1
       base_revision: edada7c56edf4a183c1735310e123c7f923584f1

--- a/packages/audioplayers/example/android/app/build.gradle.kts
+++ b/packages/audioplayers/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -17,10 +16,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     defaultConfig {
         applicationId = "xyz.luan.audioplayers.example"
         minSdk = flutter.minSdkVersion
@@ -34,6 +29,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/audioplayers/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/audioplayers/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/packages/audioplayers/example/android/settings.gradle.kts
+++ b/packages/audioplayers/example/android/settings.gradle.kts
@@ -20,7 +20,6 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.0.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/packages/audioplayers/example/android/settings.gradle.kts
+++ b/packages/audioplayers/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "9.0.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   # Integration tests for audioplayers_platform_interface are handled 
   # in this package to avoid maintaining multiple example apps:
   audioplayers_platform_interface: ^7.1.1
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
   integration_test:
@@ -32,4 +32,4 @@ flutter:
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers/example/server/pubspec.yaml
+++ b/packages/audioplayers/example/server/pubspec.yaml
@@ -12,5 +12,5 @@ dependencies:
   shelf_static: ^1.0.0
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   http: '>=0.13.1 <2.0.0'

--- a/packages/audioplayers/pubspec.yaml
+++ b/packages/audioplayers/pubspec.yaml
@@ -38,13 +38,13 @@ dependencies:
   uuid: '>=3.0.7 <5.0.0'
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"
 
 topics:
   - audio

--- a/packages/audioplayers_android/android/build.gradle
+++ b/packages/audioplayers_android/android/build.gradle
@@ -25,11 +25,10 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty('namespace')) {
@@ -37,12 +36,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -56,6 +51,12 @@ android {
 
     lint {
         disable 'InvalidPackage'
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/audioplayers_android/pubspec.yaml
+++ b/packages/audioplayers_android/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_android_exo/android/build.gradle
+++ b/packages/audioplayers_android_exo/android/build.gradle
@@ -25,11 +25,10 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
-    compileSdk 35
+    compileSdk 36
 
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty('namespace')) {
@@ -37,12 +36,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -56,6 +51,12 @@ android {
 
     lint {
         disable 'InvalidPackage'
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/packages/audioplayers_android_exo/pubspec.yaml
+++ b/packages/audioplayers_android_exo/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_darwin/pubspec.yaml
+++ b/packages/audioplayers_darwin/pubspec.yaml
@@ -22,10 +22,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_linux/pubspec.yaml
+++ b/packages/audioplayers_linux/pubspec.yaml
@@ -18,10 +18,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_platform_interface/pubspec.yaml
+++ b/packages/audioplayers_platform_interface/pubspec.yaml
@@ -13,10 +13,10 @@ dependencies:
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_web/pubspec.yaml
+++ b/packages/audioplayers_web/pubspec.yaml
@@ -21,10 +21,10 @@ dependencies:
   web: '>=0.5.1 <2.0.0'
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/packages/audioplayers_windows/pubspec.yaml
+++ b/packages/audioplayers_windows/pubspec.yaml
@@ -18,10 +18,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  flame_lint: ^1.4.1
+  flame_lint: ^1.4.3
   flutter_test:
     sdk: flutter
 
 environment:
   sdk: ^3.6.0
-  flutter: ">=3.35.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ workspace:
   - packages/audioplayers_windows
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.12.0
 
 dev_dependencies:
   melos: ^7.8.0
@@ -23,9 +23,9 @@ melos:
     bootstrap:
       environment:
         sdk: ^3.6.0
-        flutter: '>=3.35.0'
+        flutter: '>=3.44.0'
       dev_dependencies:
-        flame_lint: ^1.4.1
+        flame_lint: ^1.4.3
 
   scripts:
     pub-outdated:


### PR DESCRIPTION
# Description

- This raises the minimum required Flutter SDK to 3.44.x.
- Support built-in Kotlin

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

It depends whether this is considered a breaking change. I would not, as it simply doesn't get downloaded, if the flutter version isn't high enough.

## Related Issues

Fixes #1988
Fixes #1984

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
