### PR TITLE
test: Replace environment variables with internal test flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,9 +219,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
 
   android-exo:
     runs-on: ubuntu-latest
@@ -252,9 +252,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,9 +219,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
 
   android-exo:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,9 +219,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
 
   android-exo:
     runs-on: ubuntu-latest
@@ -281,9 +281,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true
       - name: Run Android unit tests
         working-directory: ./packages/audioplayers/example/android
         # TODO: Use `./gradlew test`, when https://github.com/flutter/flutter/issues/169336 is fixed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,9 +219,9 @@ jobs:
         # Need to execute lib and app tests one by one, see: https://github.com/flutter/flutter/issues/101031
         run: |
           ( cd server; dart run bin/server.dart ) &
-          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_BYTES_SOURCE=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_BYTES_SOURCE=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
-          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_BYTES_SOURCE=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/platform_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/lib_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
+          flutter test integration_test/app_test.dart --dart-define USE_LOCAL_SERVER=true --dart-define TEST_FEATURE_LOW_LATENCY=false --dart-define TEST_FEATURE_PLAYBACK_RATE=false --dart-define TEST_ANDROID_MEDIAPLAYER=true
 
   android-exo:
     runs-on: ubuntu-latest

--- a/packages/audioplayers/example/integration_test/app_test.dart
+++ b/packages/audioplayers/example/integration_test/app_test.dart
@@ -10,10 +10,10 @@ import 'app/tabs/source_tab.dart';
 import 'app/tabs/stream_tab.dart';
 import 'platform_features.dart';
 
-void main() {
-  final features = PlatformFeatures.instance();
-
+void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  await PlatformFeatures.ensureInitialized();
+  final features = PlatformFeatures.instance();
 
   group('end-to-end test', () {
     testWidgets('verify app is launched', (WidgetTester tester) async {

--- a/packages/audioplayers/example/integration_test/lib_test.dart
+++ b/packages/audioplayers/example/integration_test/lib_test.dart
@@ -15,6 +15,7 @@ import 'test_utils.dart';
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  await PlatformFeatures.ensureInitialized();
   final features = PlatformFeatures.instance();
   final isAndroid = !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
   final audioTestDataList = await getAudioTestDataList();

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -1,10 +1,5 @@
 import 'package:flutter/foundation.dart';
 
-const testFeatureBytesSource = bool.fromEnvironment(
-  'TEST_FEATURE_BYTES_SOURCE',
-  defaultValue: true,
-);
-
 const testFeaturePlaybackRate = bool.fromEnvironment(
   'TEST_FEATURE_PLAYBACK_RATE',
   defaultValue: true,
@@ -21,7 +16,7 @@ const testIsAndroidMediaPlayer = bool.fromEnvironment(
 
 /// Specify supported features for a platform.
 class PlatformFeatures {
-  static const webPlatformFeatures = PlatformFeatures(
+  static const _webPlatformFeatures = PlatformFeatures(
     hasPlaylistSourceType: false,
     hasLowLatency: false,
     hasForceSpeaker: false,
@@ -33,17 +28,15 @@ class PlatformFeatures {
     hasErrorEvent: false,
   );
 
-  static const androidPlatformFeatures = PlatformFeatures(
+  static const _androidPlatformFeatures = PlatformFeatures(
     hasRecordingActive: false,
-    // ignore: avoid_redundant_argument_values
-    hasBytesSource: testFeatureBytesSource,
     // ignore: avoid_redundant_argument_values
     hasPlaybackRate: testFeaturePlaybackRate,
     // ignore: avoid_redundant_argument_values
     hasLowLatency: testFeatureLowLatency,
   );
 
-  static const iosPlatformFeatures = PlatformFeatures(
+  static const _iosPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,
     hasBytesSource: false,
     hasPlaylistSourceType: false,
@@ -51,7 +44,7 @@ class PlatformFeatures {
     hasBalance: false,
   );
 
-  static const macPlatformFeatures = PlatformFeatures(
+  static const _macPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,
     hasBytesSource: false,
     hasPlaylistSourceType: false,
@@ -65,7 +58,7 @@ class PlatformFeatures {
     hasBalance: false,
   );
 
-  static const linuxPlatformFeatures = PlatformFeatures(
+  static const _linuxPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,
     hasBytesSource: false,
     hasLowLatency: false,
@@ -80,7 +73,7 @@ class PlatformFeatures {
     hasPlayingRoute: false,
   );
 
-  static const windowsPlatformFeatures = PlatformFeatures(
+  static const _windowsPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,
     hasPlaylistSourceType: false,
     hasLowLatency: false,
@@ -144,19 +137,19 @@ class PlatformFeatures {
     this.hasErrorEvent = true,
   });
 
+  static PlatformFeatures? _instance;
+
   factory PlatformFeatures.instance() {
-    return kIsWeb
-        ? webPlatformFeatures
-        : defaultTargetPlatform == TargetPlatform.android
-            ? androidPlatformFeatures
-            : defaultTargetPlatform == TargetPlatform.iOS
-                ? iosPlatformFeatures
-                : defaultTargetPlatform == TargetPlatform.macOS
-                    ? macPlatformFeatures
-                    : defaultTargetPlatform == TargetPlatform.linux
-                        ? linuxPlatformFeatures
-                        : defaultTargetPlatform == TargetPlatform.windows
-                            ? windowsPlatformFeatures
-                            : const PlatformFeatures();
+    _instance ??= kIsWeb
+        ? _webPlatformFeatures
+        : switch (defaultTargetPlatform) {
+            TargetPlatform.android => _androidPlatformFeatures,
+            TargetPlatform.iOS => _iosPlatformFeatures,
+            TargetPlatform.macOS => _macPlatformFeatures,
+            TargetPlatform.linux => _linuxPlatformFeatures,
+            TargetPlatform.windows => _windowsPlatformFeatures,
+            _ => const PlatformFeatures(),
+          };
+    return _instance!;
   }
 }

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -1,9 +1,7 @@
-import 'package:flutter/foundation.dart';
+import 'dart:io';
 
-const testFeatureLowLatency = bool.fromEnvironment(
-  'TEST_FEATURE_LOW_LATENCY',
-  defaultValue: true,
-);
+import 'package:flutter/foundation.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 const testIsAndroidMediaPlayer = bool.fromEnvironment(
   'TEST_ANDROID_MEDIAPLAYER',
@@ -23,11 +21,16 @@ class PlatformFeatures {
     hasErrorEvent: false,
   );
 
-  static const _androidPlatformFeatures = PlatformFeatures(
-    hasRecordingActive: false,
-    // ignore: avoid_redundant_argument_values
-    hasLowLatency: testFeatureLowLatency,
-  );
+  factory PlatformFeatures._androidPlatformFeatures() {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+    final parsed = Pubspec.parse(pubspec);
+    final usesExoPlayer =
+        parsed.dependencies.containsKey('audioplayers_android_exo');
+    return PlatformFeatures(
+      hasRecordingActive: false,
+      hasLowLatency: !usesExoPlayer,
+    );
+  }
 
   static const _iosPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,
@@ -136,7 +139,8 @@ class PlatformFeatures {
     _instance ??= kIsWeb
         ? _webPlatformFeatures
         : switch (defaultTargetPlatform) {
-            TargetPlatform.android => _androidPlatformFeatures,
+            TargetPlatform.android =>
+              PlatformFeatures._androidPlatformFeatures(),
             TargetPlatform.iOS => _iosPlatformFeatures,
             TargetPlatform.macOS => _macPlatformFeatures,
             TargetPlatform.linux => _linuxPlatformFeatures,

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -3,10 +3,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-const testIsAndroidMediaPlayer = bool.fromEnvironment(
-  'TEST_ANDROID_MEDIAPLAYER',
-);
-
 /// Specify supported features for a platform.
 class PlatformFeatures {
   static const _webPlatformFeatures = PlatformFeatures(
@@ -21,16 +17,24 @@ class PlatformFeatures {
     hasErrorEvent: false,
   );
 
-  factory PlatformFeatures._androidPlatformFeatures() {
-    final pubspec = File('pubspec.yaml').readAsStringSync();
-    final parsed = Pubspec.parse(pubspec);
-    final usesExoPlayer =
-        parsed.dependencies.containsKey('audioplayers_android_exo');
-    return PlatformFeatures(
-      hasRecordingActive: false,
-      hasLowLatency: !usesExoPlayer,
-    );
+  static bool? _usesAndroidMediaPlayer;
+
+  static bool usesAndroidMediaPlayerImpl() {
+    if (_usesAndroidMediaPlayer == null) {
+      final pubspec = File('pubspec.yaml').readAsStringSync();
+      final parsed = Pubspec.parse(pubspec);
+      // This line should check for 'audioplayers_android' as soon as
+      // 'audioplayers_android_exo' becomes the default implementation.
+      _usesAndroidMediaPlayer =
+          !parsed.dependencies.containsKey('audioplayers_android_exo');
+    }
+    return _usesAndroidMediaPlayer!;
   }
+
+  factory PlatformFeatures._androidPlatformFeatures() => PlatformFeatures(
+        hasRecordingActive: false,
+        hasLowLatency: usesAndroidMediaPlayerImpl(),
+      );
 
   static const _iosPlatformFeatures = PlatformFeatures(
     hasDataUriSource: false,

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 /// Specify supported features for a platform.
@@ -19,10 +18,10 @@ class PlatformFeatures {
 
   static bool? _usesAndroidMediaPlayer;
 
-  static bool usesAndroidMediaPlayerImpl() {
+  static Future<bool> usesAndroidMediaPlayerImpl() async {
     if (_usesAndroidMediaPlayer == null) {
-      final pubspec = File('pubspec.yaml').readAsStringSync();
-      final parsed = Pubspec.parse(pubspec);
+      final yamlContent = await rootBundle.loadString('pubspec.yaml');
+      final parsed = Pubspec.parse(yamlContent);
       // This line should check for 'audioplayers_android' as soon as
       // 'audioplayers_android_exo' becomes the default implementation.
       _usesAndroidMediaPlayer =
@@ -31,9 +30,10 @@ class PlatformFeatures {
     return _usesAndroidMediaPlayer!;
   }
 
-  factory PlatformFeatures._androidPlatformFeatures() => PlatformFeatures(
+  static Future<PlatformFeatures> _getAndroidPlatformFeatures() async =>
+      PlatformFeatures(
         hasRecordingActive: false,
-        hasLowLatency: usesAndroidMediaPlayerImpl(),
+        hasLowLatency: await usesAndroidMediaPlayerImpl(),
       );
 
   static const _iosPlatformFeatures = PlatformFeatures(
@@ -139,18 +139,25 @@ class PlatformFeatures {
 
   static PlatformFeatures? _instance;
 
-  factory PlatformFeatures.instance() {
+  static Future<void> ensureInitialized() async {
     _instance ??= kIsWeb
         ? _webPlatformFeatures
         : switch (defaultTargetPlatform) {
-            TargetPlatform.android =>
-              PlatformFeatures._androidPlatformFeatures(),
+            TargetPlatform.android => await _getAndroidPlatformFeatures(),
             TargetPlatform.iOS => _iosPlatformFeatures,
             TargetPlatform.macOS => _macPlatformFeatures,
             TargetPlatform.linux => _linuxPlatformFeatures,
             TargetPlatform.windows => _windowsPlatformFeatures,
             _ => const PlatformFeatures(),
           };
+  }
+
+  factory PlatformFeatures.instance() {
+    if (_instance == null) {
+      throw Exception(
+          'Make sure you call "PlatformFeatures.ensureInitialized()" before '
+          'accessing the instance.');
+    }
     return _instance!;
   }
 }

--- a/packages/audioplayers/example/integration_test/platform_features.dart
+++ b/packages/audioplayers/example/integration_test/platform_features.dart
@@ -1,10 +1,5 @@
 import 'package:flutter/foundation.dart';
 
-const testFeaturePlaybackRate = bool.fromEnvironment(
-  'TEST_FEATURE_PLAYBACK_RATE',
-  defaultValue: true,
-);
-
 const testFeatureLowLatency = bool.fromEnvironment(
   'TEST_FEATURE_LOW_LATENCY',
   defaultValue: true,
@@ -30,8 +25,6 @@ class PlatformFeatures {
 
   static const _androidPlatformFeatures = PlatformFeatures(
     hasRecordingActive: false,
-    // ignore: avoid_redundant_argument_values
-    hasPlaybackRate: testFeaturePlaybackRate,
     // ignore: avoid_redundant_argument_values
     hasLowLatency: testFeatureLowLatency,
   );

--- a/packages/audioplayers/example/integration_test/platform_test.dart
+++ b/packages/audioplayers/example/integration_test/platform_test.dart
@@ -33,7 +33,10 @@ bool canDetermineDuration(SourceTestData td) {
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  await PlatformFeatures.ensureInitialized();
   final features = PlatformFeatures.instance();
+  final usesAndroidMediaPlayerImplementation =
+      isAndroid && await PlatformFeatures.usesAndroidMediaPlayerImpl();
   final audioTestDataList = await getAudioTestDataList();
 
   group('Platform method channel', () {
@@ -95,7 +98,7 @@ void main() async {
       //  Further, the other future is not fulfilled and then mysteriously
       //  failing in later tests.
       //  The feature works with audioplayers_android_exo.
-      skip: isAndroid && PlatformFeatures.usesAndroidMediaPlayerImpl(),
+      skip: usesAndroidMediaPlayerImplementation,
     );
 
     testWidgets('#create and #dispose', (tester) async {

--- a/packages/audioplayers/example/integration_test/platform_test.dart
+++ b/packages/audioplayers/example/integration_test/platform_test.dart
@@ -95,7 +95,7 @@ void main() async {
       //  Further, the other future is not fulfilled and then mysteriously
       //  failing in later tests.
       //  The feature works with audioplayers_android_exo.
-      skip: testIsAndroidMediaPlayer,
+      skip: isAndroid && PlatformFeatures.usesAndroidMediaPlayerImpl(),
     );
 
     testWidgets('#create and #dispose', (tester) async {

--- a/packages/audioplayers/example/pubspec.yaml
+++ b/packages/audioplayers/example/pubspec.yaml
@@ -23,12 +23,14 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   pub_semver: ^2.2.0
+  pubspec_parse: ^1.5.0
 
 flutter:
   uses-material-design: true
 
   assets:
     - assets/
+    - pubspec.yaml
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
# Description

Before this change, one had to hand over many environment variables, in order to get the tests pass locally. This change reduces this need, so most of the tests will work out of the box.

Remove / replace environment flags for:

- TEST_FEATURE_BYTES_SOURCE: Min SDK of Flutter is 24, so it has no relevance in min tests any more
- TEST_FEATURE_PLAYBACK_RATE: Min SDK of Flutter is 24, so it has no relevance in min tests any more
- TEST_FEATURE_LOW_LATENCY: Replaced by `usesAndroidMediaPlayerImpl`
- TEST_ANDROID_MEDIAPLAYER: Replaced by `usesAndroidMediaPlayerImpl` by checking the used dependencies

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
