### PR TITLE
fix(android): Reset prepared state on ExoPlayer STATE_IDLE in audioplayers_android_exo

### DIFF
--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
@@ -56,7 +56,10 @@ class ExoPlayerWrapper(
 
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
-                Player.STATE_IDLE -> {} // TODO(gustl22): may can use or leave as no-op
+                // IDLE is reached on creation, after stop()/release() and after a playback
+                // error. In all cases the player needs prepare() before it can play again,
+                // so the wrapper must no longer report itself as prepared.
+                Player.STATE_IDLE -> wrappedPlayer.onIdle()
                 Player.STATE_BUFFERING -> wrappedPlayer.onBuffering(0)
                 Player.STATE_READY -> wrappedPlayer.onPrepared()
                 Player.STATE_ENDED -> wrappedPlayer.onCompletion()

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -256,6 +256,16 @@ class WrappedPlayer internal constructor(
         // TODO(luan): expose this as a stream
     }
 
+    /**
+     * The player left its prepared state and needs [PlayerWrapper.prepare] before it can
+     * play again, e.g. after a playback error. Resetting [prepared] also notifies the Dart
+     * side (`audio.onPrepared` with `value: false`), which otherwise would still consider
+     * the player prepared after an error.
+     */
+    fun onIdle() {
+        prepared = false
+    }
+
     fun onSeekComplete() {
         ref.handleSeekComplete(this)
     }


### PR DESCRIPTION
# Description

`onPlaybackStateChanged` currently treats `Player.STATE_IDLE` as a no-op (`TODO(gustl22): may can use or leave as no-op`). ExoPlayer enters `STATE_IDLE` after a playback error (and after `stop()`/`release()`), and from IDLE it cannot play again without a new `prepare()`.

Leaving `prepared = true` after an error means both sides keep believing the player is usable:

- `WrappedPlayer.resume()` calls `play()` on an idle player — a silent no-op, audio just never starts;
- the Dart side never receives `audio.onPrepared` with `value: false`, so `getDuration()`/`getCurrentPosition()` keep being queried on a dead player.

This resets `prepared` via a new `WrappedPlayer.onIdle()` callback. For the intentional IDLE paths (player creation, `release()`, source set to `null`) this is a no-op: the `prepared` setter only reacts to actual value changes, and those flows already reset it before the async listener callback arrives.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality — no test infra exists for the Kotlin layer of this package.
- [x] I have updated/added relevant documentation — KDoc added on `onIdle()` explaining when it fires and why.
- [x] I have updated/added relevant examples in `examples` — reproducible in the example app: stream a URL, kill connectivity mid-playback until ExoPlayer errors out, observe that without this patch no `onPrepared(false)` event arrives.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Complements the error path of #1721 (background audio stops and never recovers): after this change, apps can at least observe the unprepared state and re-prepare.
