### PR TITLE
fix(audioplayers_android_exo): honor stayAwake by setting the ExoPlayer wake mode

### DIFF
--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
@@ -173,6 +173,13 @@ class ExoPlayerWrapper(
             builder.build(),
             false,
         )
+        // Parity with MediaPlayerWrapper, which maps `stayAwake` to
+        // MediaPlayer.setWakeMode(PARTIAL_WAKE_LOCK). WAKE_MODE_NETWORK also
+        // holds a WifiLock so network streams keep buffering while the screen
+        // is off; for local sources it behaves like WAKE_MODE_LOCAL.
+        player.setWakeMode(
+            if (context.stayAwake) C.WAKE_MODE_NETWORK else C.WAKE_MODE_NONE,
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.M)


### PR DESCRIPTION
## Description

`AudioContextAndroid(stayAwake: true)` is silently ignored by the ExoPlayer implementation: the flag is parsed from the method channel but never consumed (no `setWakeMode`/wake lock anywhere in the package).

The [feature parity table](https://github.com/bluefireteam/audioplayers/blob/main/feature_parity_table.md) lists **stay awake** as supported on Android, and `audioplayers_android` does implement it — `MediaPlayerWrapper.updateContext` maps `stayAwake` to `MediaPlayer.setWakeMode(PARTIAL_WAKE_LOCK)`:

https://github.com/bluefireteam/audioplayers/blob/main/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/player/MediaPlayerWrapper.kt#L80-L85

So apps that switch to the ExoPlayer implementation lose a documented Android feature without any signal.

## Fix

Map `stayAwake` to `ExoPlayer.setWakeMode(C.WAKE_MODE_NETWORK)` in `ExoPlayerWrapper.updateContext` (and `WAKE_MODE_NONE` when false). `WAKE_MODE_NETWORK` holds the same partial wake lock as the MediaPlayer counterpart, plus a WifiLock so network streams keep buffering while the screen is off — which is the main real-world reason to use `stayAwake` with streamed audio (e.g. meditation/podcast apps where the screen is locked during playback). For local sources it behaves like `WAKE_MODE_LOCAL`.

As with `audioplayers_android`, the app must hold the `WAKE_LOCK` permission for the flag to take effect ([Media3 docs](https://developer.android.com/reference/androidx/media3/common/Player#setWakeMode(int))).

## Context

Found while debugging locked-screen playback stalls in a meditation app that uses `audioplayers_android_exo` in production.
