### PR TITLE
feat: configurable back buffer duration (fast/offline backwards seeks)

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -343,6 +343,23 @@ class AudioPlayer {
     return _platform.setPlaybackRate(playerId, playbackRate);
   }
 
+  /// Sets how much already-played media to retain in the buffer, enabling
+  /// fast backwards seeks within that window without re-fetching the media —
+  /// including offline, once the content is buffered (useful for the typical
+  /// "rewind 10 seconds" button).
+  ///
+  /// Pass `null` to restore the platform default.
+  ///
+  /// Currently only effective on Android when using the ExoPlayer
+  /// implementation (`audioplayers_android_exo`), where changing the value
+  /// re-creates the underlying player (a brief pause may be noticeable if
+  /// called during playback — prefer setting it before playing). Other
+  /// platforms manage their buffers internally and ignore this call.
+  Future<void> setBackBufferDuration(Duration? duration) async {
+    await creatingCompleter.future;
+    return _platform.setBackBufferDuration(playerId, duration);
+  }
+
   /// Sets the audio source for this player.
   ///
   /// This will delegate to one of the specific methods below depending on

--- a/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -153,6 +153,10 @@ class AudioplayersPlugin : FlutterPlugin {
                     player.rate = rate.toFloat()
                 }
 
+                "setBackBufferDuration" -> {
+                    // No-op: MediaPlayer manages its buffer internally.
+                }
+
                 "getDuration" -> {
                     response.success(player.getDuration())
                     return

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/AudioplayersPlugin.kt
@@ -149,6 +149,11 @@ class AudioplayersPlugin : FlutterPlugin {
                     player.rate = rate.toFloat()
                 }
 
+                "setBackBufferDuration" -> {
+                    // null restores the platform default (no back buffer).
+                    player.backBufferDurationMs = call.argument<Int>("backBufferDurationMs") ?: 0
+                }
+
                 "getDuration" -> {
                     response.success(player.getDuration())
                     return

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
@@ -35,11 +35,6 @@ class ExoPlayerWrapper(
     appContext: Context,
 ) : PlayerWrapper {
 
-    companion object {
-        /** How much already-played media to retain, enabling fast/offline seek-backs. */
-        private const val BACK_BUFFER_DURATION_MS = 30_000
-    }
-
     class ExoPlayerListener(private val wrappedPlayer: WrappedPlayer) : androidx.media3.common.Player.Listener {
         override fun onPlayerError(error: PlaybackException) {
             if (error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
@@ -97,11 +92,12 @@ class ExoPlayerWrapper(
 
         // DefaultLoadControl discards media as soon as it has been played
         // (back buffer of 0): any seek backwards — even a 10s rewind — drops
-        // the whole buffer and re-fetches from the network. Retaining a short
-        // back buffer makes small rewinds instant and lets them work offline
-        // once the content is buffered. ~30s of audio is well under 1 MB.
+        // the whole buffer and re-fetches from the network. Apps can opt into
+        // retaining a window of played media via setBackBufferDuration, which
+        // makes small rewinds instant and lets them work offline once the
+        // content is buffered. 0 keeps the platform default.
         val loadControl = DefaultLoadControl.Builder()
-            .setBackBuffer(BACK_BUFFER_DURATION_MS, true)
+            .setBackBuffer(wrappedPlayer.backBufferDurationMs, true)
             .build()
 
         return ExoPlayer.Builder(appContext)

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/ExoPlayerWrapper.kt
@@ -17,6 +17,7 @@ import androidx.media3.common.audio.BaseAudioProcessor
 import androidx.media3.common.audio.ChannelMixingMatrix
 import androidx.media3.datasource.ByteArrayDataSource
 import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
@@ -33,6 +34,11 @@ class ExoPlayerWrapper(
     private val wrappedPlayer: WrappedPlayer,
     appContext: Context,
 ) : PlayerWrapper {
+
+    companion object {
+        /** How much already-played media to retain, enabling fast/offline seek-backs. */
+        private const val BACK_BUFFER_DURATION_MS = 30_000
+    }
 
     class ExoPlayerListener(private val wrappedPlayer: WrappedPlayer) : androidx.media3.common.Player.Listener {
         override fun onPlayerError(error: PlaybackException) {
@@ -89,9 +95,22 @@ class ExoPlayerWrapper(
             }
         }
 
-        return ExoPlayer.Builder(appContext).setRenderersFactory(renderersFactory).build().apply {
-            addListener(ExoPlayerListener(wrappedPlayer))
-        }
+        // DefaultLoadControl discards media as soon as it has been played
+        // (back buffer of 0): any seek backwards — even a 10s rewind — drops
+        // the whole buffer and re-fetches from the network. Retaining a short
+        // back buffer makes small rewinds instant and lets them work offline
+        // once the content is buffered. ~30s of audio is well under 1 MB.
+        val loadControl = DefaultLoadControl.Builder()
+            .setBackBuffer(BACK_BUFFER_DURATION_MS, true)
+            .build()
+
+        return ExoPlayer.Builder(appContext)
+            .setRenderersFactory(renderersFactory)
+            .setLoadControl(loadControl)
+            .build()
+            .apply {
+                addListener(ExoPlayerListener(wrappedPlayer))
+            }
     }
 
     override fun getDuration(): Int? {

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -96,6 +96,37 @@ class WrappedPlayer internal constructor(
     var playing = false
     var shouldSeekTo = -1
 
+    /**
+     * How much already-played media to retain in the buffer (enables fast and
+     * offline backwards seeks within the window). 0 keeps the platform
+     * default (ExoPlayer discards played media right away).
+     *
+     * ExoPlayer's LoadControl can only be set at construction time, so
+     * changing the value re-creates the player — mirroring how the
+     * MediaPlayer implementation handles `playerMode` changes (playback may
+     * pause briefly when changed mid-play).
+     */
+    var backBufferDurationMs: Int = 0
+        set(value) {
+            if (field != value) {
+                field = value
+                player?.let {
+                    shouldSeekTo = try {
+                        it.getCurrentPosition()
+                    } catch (e: Exception) {
+                        -1
+                    }
+                    prepared = false
+                    it.dispose()
+                }
+                player = createPlayer()
+                source?.let {
+                    player?.setSource(it)
+                    player?.configAndPrepare()
+                }
+            }
+        }
+
     private val focusManager = FocusManager.create(
         this,
         onGranted = {

--- a/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
+++ b/packages/audioplayers_android_exo/android/src/main/kotlin/xyz/luan/audioplayers/player/WrappedPlayer.kt
@@ -112,7 +112,7 @@ class WrappedPlayer internal constructor(
                 field = value
                 player?.let {
                     shouldSeekTo = try {
-                        it.getCurrentPosition()
+                        it.getCurrentPosition() ?: -1
                     } catch (e: Exception) {
                         -1
                     }

--- a/packages/audioplayers_darwin/darwin/audioplayers_darwin/Sources/audioplayers_darwin/AudioplayersDarwinPlugin.swift
+++ b/packages/audioplayers_darwin/darwin/audioplayers_darwin/Sources/audioplayers_darwin/AudioplayersDarwinPlugin.swift
@@ -280,6 +280,8 @@ public class AudioplayersDarwinPlugin: NSObject, FlutterPlugin {
       let currentPosition = player.getCurrentPosition()
       result(currentPosition)
       return
+    } else if method == "setBackBufferDuration" {
+      // No-op: AVPlayer manages its buffer internally.
     } else if method == "setPlaybackRate" {
       guard let playbackRate = args["playbackRate"] as? Double else {
         result(

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -181,7 +181,7 @@ static void audioplayers_linux_plugin_handle_method_call(
       result = optPosition.has_value() ? fl_value_new_int(optPosition.value())
                                        : nullptr;
     } else if (strcmp(method, "setBackBufferDuration") == 0) {
-        // No-op: GStreamer manages its buffer internally.
+      // No-op: GStreamer manages its buffer internally.
     } else if (strcmp(method, "setPlaybackRate") == 0) {
       auto flPlaybackRate = fl_value_lookup_string(args, "playbackRate");
       double playbackRate =

--- a/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
+++ b/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc
@@ -180,6 +180,8 @@ static void audioplayers_linux_plugin_handle_method_call(
       auto optPosition = player->GetPosition();
       result = optPosition.has_value() ? fl_value_new_int(optPosition.value())
                                        : nullptr;
+    } else if (strcmp(method, "setBackBufferDuration") == 0) {
+        // No-op: GStreamer manages its buffer internally.
     } else if (strcmp(method, "setPlaybackRate") == 0) {
       auto flPlaybackRate = fl_value_lookup_string(args, "playbackRate");
       double playbackRate =

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform.dart
@@ -125,6 +125,15 @@ mixin MethodChannelAudioplayersPlatform
   }
 
   @override
+  Future<void> setBackBufferDuration(String playerId, Duration? duration) {
+    return _call(
+      'setBackBufferDuration',
+      playerId,
+      <String, dynamic>{'backBufferDurationMs': duration?.inMilliseconds},
+    );
+  }
+
+  @override
   Future<void> setReleaseMode(String playerId, ReleaseMode releaseMode) {
     return _call(
       'setReleaseMode',

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
@@ -32,6 +32,11 @@ abstract class AudioplayersPlatformInterface extends PlatformInterface
   /// class that extends [AudioplayersPlatformInterface] when they register
   /// themselves.
   static AudioplayersPlatformInterface instance = AudioplayersPlatform();
+
+  /// Default no-op so platform implementations that don't support
+  /// configuring the back buffer keep working unchanged.
+  @override
+  Future<void> setBackBufferDuration(String playerId, Duration? duration);
 }
 
 abstract class MethodChannelAudioplayersPlatformInterface {
@@ -87,6 +92,15 @@ abstract class MethodChannelAudioplayersPlatformInterface {
   /// iOS and macOS have limits between 0.5 and 2x
   /// Android SDK version should be 23 or higher
   Future<void> setPlaybackRate(String playerId, double playbackRate);
+
+  /// Sets how much already-played media to retain in the buffer, enabling
+  /// fast (and, once buffered, offline) backwards seeks within that window.
+  ///
+  /// A null [duration] restores the platform default.
+  /// Currently only effective on Android when using the ExoPlayer
+  /// implementation (`audioplayers_android_exo`); other platforms manage
+  /// their buffers internally and ignore this call.
+  Future<void> setBackBufferDuration(String playerId, Duration? duration);
 
   /// Configures the player to read the audio from a URL.
   ///

--- a/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
+++ b/packages/audioplayers_platform_interface/lib/src/audioplayers_platform_interface.dart
@@ -36,7 +36,8 @@ abstract class AudioplayersPlatformInterface extends PlatformInterface
   /// Default no-op so platform implementations that don't support
   /// configuring the back buffer keep working unchanged.
   @override
-  Future<void> setBackBufferDuration(String playerId, Duration? duration);
+  Future<void> setBackBufferDuration(String playerId, Duration? duration) =>
+      Future.value();
 }
 
 abstract class MethodChannelAudioplayersPlatformInterface {

--- a/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
+++ b/packages/audioplayers_platform_interface/test/audioplayers_platform_test.dart
@@ -77,6 +77,30 @@ void main() {
       expect(call.args, {'playerId': 'p1'});
     });
 
+    test('#setBackBufferDuration', () async {
+      await platform.setBackBufferDuration(
+        'p1',
+        const Duration(seconds: 30),
+      );
+      final call = popLastCall();
+      expect(call.method, 'setBackBufferDuration');
+      expect(call.args, {
+        'playerId': 'p1',
+        'backBufferDurationMs': 30000,
+      });
+    });
+
+    test('#setBackBufferDuration with null restores the platform default',
+        () async {
+      await platform.setBackBufferDuration('p1', null);
+      final call = popLastCall();
+      expect(call.method, 'setBackBufferDuration');
+      expect(call.args, {
+        'playerId': 'p1',
+        'backBufferDurationMs': null,
+      });
+    });
+
     test('#getDuration', () async {
       final duration = await platform.getDuration('p1');
       final call = popLastCall();

--- a/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
+++ b/packages/audioplayers_windows/windows/audioplayers_windows_plugin.cpp
@@ -223,6 +223,8 @@ void AudioplayersWindowsPlugin::HandleMethodCall(
                         ? EncodableValue(std::monostate{})
                         : EncodableValue(ConvertSecondsToMs(position)));
     return;
+  } else if (method_call.method_name().compare("setBackBufferDuration") == 0) {
+    // No-op: the media foundation player manages its buffer internally.
   } else if (method_call.method_name().compare("setPlaybackRate") == 0) {
     auto playbackRate = GetArgument<double>("playbackRate", args, 1.0);
     player->SetPlaybackSpeed(playbackRate);


### PR DESCRIPTION
## Description

The ExoPlayer implementation uses `DefaultLoadControl` defaults, which include [`DEFAULT_BACK_BUFFER_DURATION_MS = 0`](https://developer.android.com/reference/androidx/media3/exoplayer/DefaultLoadControl#DEFAULT_BACK_BUFFER_DURATION_MS()): media is discarded the moment it has been played. Any backwards seek — even the 10s rewind button that is standard in audiobook/podcast/meditation apps — lands outside the buffer, so ExoPlayer drops the entire forward buffer too and re-fetches everything from the new position. On a flaky or absent connection this turns a tiny rewind into a stall, even when the whole file had already been buffered moments before.

## Change (updated per review feedback)

Following @Gustl22's suggestion, this now exposes the back buffer as a **user-configurable, per-player option** instead of changing the default — each platform's default stays untouched:

```dart
final player = AudioPlayer();
await player.setBackBufferDuration(const Duration(seconds: 30));
// ... null restores the platform default
```

- **audioplayers**: new `AudioPlayer.setBackBufferDuration(Duration?)` with docs on platform support.
- **audioplayers_platform_interface**: new method with a default no-op (existing platform implementations keep working unchanged), method-channel implementation and tests.
- **audioplayers_android_exo**: real implementation. ExoPlayer's `LoadControl` is fixed at construction time, so changing the value re-creates the player preserving position/state — mirroring how the MediaPlayer implementation already handles `playerMode` changes.
- **audioplayers_android / darwin / windows / linux**: explicit no-op handlers (these players manage their buffers internally), so calling the method is safe and consistent on every platform.

## Context

Found while debugging a production meditation app where users rewind 10s with the screen locked / on unstable connections; today that reliably drops and re-downloads the buffer.
