### PR TITLE
fix: Avoid throwing a StateError in AudioPlayer._completePrepared

### DIFF
--- a/packages/audioplayers/lib/src/audioplayer.dart
+++ b/packages/audioplayers/lib/src/audioplayer.dart
@@ -359,7 +359,10 @@ class AudioPlayer {
     await creatingCompleter.future;
 
     final preparedFuture = _onPrepared
-        .firstWhere((isPrepared) => isPrepared)
+        .firstWhere(
+          (isPrepared) => isPrepared,
+          orElse: () => throw Exception('Stream closed before it got prepared'),
+        )
         .timeout(AudioPlayer.preparationTimeout);
     // Need to await the setting the source to propagate immediate errors.
     final setSourceFuture = setSource();


### PR DESCRIPTION
# Description

The event stream can be closed before it gets prepared. In that case, a StateError is thrown.

Error represents a program failure that the programmer should have avoided. Switch to an Exception with a clear message instead.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

<!-- Does your PR require audioplayers users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!" 
(for example, `feat!:`, `fix!:`). See [Conventional Commit] for details. -->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- If the PR is breaking, uncomment the following section and add instructions for how to migrate from
the currently released version to the new proposed way. -->

<!--
### Migration instructions

Before:
```
```

After:
```
```
-->

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxx !-->

Fixes https://github.com/bluefireteam/audioplayers/issues/2005

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
