### PR TITLE
fix(windows): Compatibility with Visual Studio 18 (2026)

### DIFF
--- a/packages/audioplayers/example/windows/CMakeLists.txt
+++ b/packages/audioplayers/example/windows/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Project-level configuration.
+# Audioplayers uses libraries, which require CMP0091 NEW policy: https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091
+# So one can either raise the minimum required version to 3.15 (which enables this by default), or set `cmake_policy(SET CMP0091 NEW)`.
 cmake_minimum_required(VERSION 3.15)
 project(audioplayers_example LANGUAGES CXX)
 
@@ -38,7 +40,7 @@ add_definitions(-DUNICODE -D_UNICODE)
 # default. In most cases, you should add new options to specific targets instead
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
-  target_compile_features(${TARGET} PUBLIC cxx_std_23)
+  target_compile_features(${TARGET} PUBLIC cxx_std_17)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")

--- a/packages/audioplayers_windows/README.md
+++ b/packages/audioplayers_windows/README.md
@@ -24,6 +24,32 @@ This package will be automatically included in your app when you do, so you do n
 
 ## Setup for Windows
 
+### Flutter
+
 Please follow the Flutter guide to [set up Flutter on Windows](https://docs.flutter.dev/get-started/install/windows#windows-setup).
+
+### Requirements
+
+With **Visual Studio 18 (2026)**, Audioplayers is depending on libraries, which require [CMP0091 NEW policy](https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091).
+Therefore, we recommend changing your `windows/CMakeLists.txt` as follows:
+
+```diff
+-cmake_minimum_required(VERSION 3.14)
++cmake_minimum_required(VERSION 3.15)
+
+# ...
+
+-cmake_policy(VERSION 3.14...3.25)
++cmake_policy(VERSION 3.15...3.25)
+```
+
+Alternatively apply the CMP0091 policy before the first occurrence of `project()`:
+
+```diff
++cmake_policy(SET CMP0091 NEW)
+project(my_project_name LANGUAGES CXX)
+```
+
+### Optional
 
 Optionally you can add the individual component `NuGet package manager` inside **Visual Studio** or **Visual Studio Build Tools**, otherwise it will be downloaded while building.

--- a/packages/audioplayers_windows/windows/CMakeLists.txt
+++ b/packages/audioplayers_windows/windows/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(${PLUGIN_NAME} SHARED
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
+target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_20)
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.ImplementationLibrary/build/native/Microsoft.Windows.ImplementationLibrary.targets)
 target_link_libraries(${PLUGIN_NAME} PRIVATE Mfplat windowsapp)


### PR DESCRIPTION
# Description

In #2004 I fixed the Visual Studio 18 compatibility. But there is one optimization one can do by adding the required cxx_std_20 lib to the CMakeLists.txt of the package, so no manual add in the project CMakeLists.txt is required (at least not this part).
But still one needs to raise the cmake_minimum_required version.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `refactor:`,
      `docs:`, `chore:`, `test:`, `ci:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`, where necessary.
- [x] I have updated/added relevant examples in [example].

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

https://github.com/flutter/flutter/issues/185597#issuecomment-4796717055
#1985

<!-- Links -->
[issue database]: https://github.com/bluefireteam/audioplayers/issues
[Contributor Guide]: https://github.com/bluefireteam/audioplayers/blob/main/contributing.md#feature-requests--prs
[Conventional Commit]: https://conventionalcommits.org
[example]: https://github.com/bluefireteam/audioplayers/tree/main/packages/audioplayers/example
