### PR TITLE
fix(darwin): compile on newer Xcode SDKs — pin swift_version, use CMTime initializer

### DIFF
--- a/packages/audioplayers_darwin/darwin/audioplayers_darwin.podspec
+++ b/packages/audioplayers_darwin/darwin/audioplayers_darwin.podspec
@@ -17,6 +17,12 @@ Pod::Spec.new do |s|
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
+  # Pin the Swift language mode: without it, newer Xcode images compile the pod
+  # in their default (Swift 6) mode, where recent SDKs no longer expose the
+  # Swift 4.2-era nested refinements (AVAudioSession.Category.playback etc.),
+  # breaking AudioContext.swift with "has no member" / typedef degradation
+  # errors. See https://github.com/bluefireteam/audioplayers/issues/1955
+  s.swift_version = '5.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/audioplayers_darwin/darwin/audioplayers_darwin/Sources/audioplayers_darwin/Utils.swift
+++ b/packages/audioplayers_darwin/darwin/audioplayers_darwin/Sources/audioplayers_darwin/Utils.swift
@@ -18,7 +18,10 @@ func toCMTime(millis: Double) -> CMTime {
 }
 
 func toCMTime(millis: Float) -> CMTime {
-  return CMTimeMakeWithSeconds(Float64(millis) / 1000, preferredTimescale: Int32(NSEC_PER_SEC))
+  // The Swift-native initializer instead of CMTimeMakeWithSeconds: recent SDKs
+  // (e.g. iPhoneOS 26.4) drop the `preferredTimescale:` label from the C shim,
+  // while CMTime(seconds:preferredTimescale:) is stable across all SDKs.
+  return CMTime(seconds: Float64(millis) / 1000, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
 }
 
 func fromCMTime(time: CMTime) -> Int {


### PR DESCRIPTION
# Description

On newer Xcode images (observed: Xcode 26.4 with the iPhoneOS 26.4 SDK on Codemagic), the `audioplayers_darwin` pod fails to compile with the symptom class tracked in #1955:

```
Utils.swift:21:31: error: extraneous argument label 'preferredTimescale:' in call
AudioContext.swift:9:24: type 'AVAudioSession.Category' (aka 'NSString') has no member 'playback'
(+ .ambient/.soloAmbient/.record/.playAndRecord/.multiRoute, and setCategory not accepting Category)
```

**Root cause:** `audioplayers_darwin.podspec` sets no `s.swift_version`, so newer toolchains compile the pod in their default Swift 6 language mode, where the SDK no longer exposes the Swift 4.2-era nested `AVAudioSession` refinements — `Category` degrades to its ObjC `NSString` typedef. (Diagnosed by comparing against another plugin pod that compiles the identical `AVAudioSession.Category.playback` syntax green on the same image — it pins `s.swift_version`; import changes make no difference.) `CMTimeMakeWithSeconds` similarly loses its `preferredTimescale:` label.

**Fix (two minimal changes):**
- `audioplayers_darwin.podspec`: `s.swift_version = '5.0'`
- `Utils.swift`: use `CMTime(seconds:preferredTimescale:)` — the Swift-native initializer, stable across all SDKs

Verified on Codemagic's Xcode 26.4 image: a previously-failing app build compiles and ships green with exactly these changes (via a git `dependency_overrides` fork). Older toolchains are unaffected (`swift_version 5.0` is what most plugin pods pin; the CMTime initializer typechecks back to old SDKs).

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality (N/A — build-configuration fix; no runtime behavior change).
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///` (N/A — comments added inline where the change lives).
- [ ] I have updated/added relevant examples in `examples` (N/A).

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

#1955